### PR TITLE
feat(setup): add first-class native Windows support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,22 @@ Deliberate decisions in this repo - do NOT silently revert them:
 - Claude Code and pi share one harness configuration; there is no Claude-specific copy to edit. Skills live in `home/.agents/skills/`, subagents in `home/.pi/agent/agents/`, session-start actions in `home/.pi/agent/hook/session-start.sh` (referenced by both `hooks.yaml` and `home/.config/.claude/settings.json`), and MCP servers in `home/.config/mcp/mcp.json` (synced into Claude's stateful `~/.claude.json` by `home.activation.syncClaudeMcp` in `home.nix`). Edit the shared source, not `~/.claude/*`.
 - A path under `~` that a third-party installer writes to must not be an out-of-store symlink into this repo: those writes follow symlinks straight into the tracked, public checkout. `home.nix` handles the three known cases differently on purpose - suppress the write (`--skip-skills` for the twg installer), merge instead of link (`syncClaudeMcp`, `syncClaudeSettings`), or accept the write because the target is unmanaged. Check which applies before adding a `home.file` entry or an installer call.
 
+## Two platforms
+
+macOS is Nix (`configuration.nix` + `home.nix`); Windows is `setup/windows.sh` alone, because Nix has no native Windows support. Windows means native Windows in Git for Windows' bash - not WSL - and the shell there is bash, not zsh.
+
+`setup/windows-parity.md` maps every macOS package, config and system default to its Windows decision. It is the contract, not a summary: anything added to either platform needs a row there. Some lists (npm globals, Go CLIs, secrets) are necessarily duplicated between `home.nix` and `setup/windows.sh` - bump both.
+
+Scripts in `home/bin/` are bash so they run on both platforms. Validate them with `shellcheck`, not `zsh -n`; only `rebuild.sh` is still zsh.
+
 ## Validating changes without mutating the machine
 
-This repo configures a real machine and agent sessions usually run on that machine. `setup.sh`, `setup/macOS.sh`, `rebuild.sh`, `darwin-rebuild switch`, `brew`, `mas`, `pi install`, and `npm install -g` all change live state, so none of them are validation steps. Use instead:
+This repo configures a real machine and agent sessions usually run on that machine. `setup.sh`, `setup/macOS.sh`, `setup/windows.sh`, `rebuild.sh`, `darwin-rebuild switch`, `brew`, `mas`, `winget`, `pi install`, and `npm install -g` all change live state, so none of them are validation steps. Use instead:
 
 - `nix flake check` and `nix eval .#darwinConfigurations.mac.system.outPath` - evaluate the entire configuration without activating it.
-- `shellcheck` for the bash scripts, but `zsh -n` for `rebuild.sh` and everything in `home/bin/`; shellcheck rejects zsh outright (SC1071).
+- `shellcheck` for the bash scripts, including `setup/windows.sh`, `home/.bashrc` and everything in `home/bin/`. `zsh -n` only for `rebuild.sh`; shellcheck rejects zsh outright (SC1071).
+
+Sessions normally run on the macOS machine, so the Windows path cannot be executed at all from here. `shellcheck` and `bash -n` are the whole of what can be checked; say plainly what stayed unverified rather than implying it was tested. Verify winget package ids against the `microsoft/winget-pkgs` manifests (`gh api repos/microsoft/winget-pkgs/contents/manifests/<first-letter>/<Publisher>/<Package>`) instead of trusting a remembered id.
 
 This repo has no CI: there is no `.github/` directory, so pull requests legitimately report zero checks. Do not add a workflow to make a pipeline look green.
 

--- a/home.nix
+++ b/home.nix
@@ -285,8 +285,9 @@ in
 
     # Personal host entries live in ~/.ssh/config.local (untracked, Included
     # from here) since this repo is public. OS-specific bits (the 1Password
-    # IdentityAgent path on macOS; nothing needed on WSL) come via
-    # ~/.ssh/config-os, same split as .gitconfig-os above.
+    # IdentityAgent socket on macOS; on Windows 1Password serves the OpenSSH
+    # named pipe instead) come via ~/.ssh/config-os, same split as
+    # .gitconfig-os above.
     ".ssh/config".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfiles}/home/.ssh/config";
     ".ssh/config-os".source =

--- a/home.nix
+++ b/home.nix
@@ -4,6 +4,10 @@ let
   dotfiles = "${config.home.homeDirectory}/.dotfiles";
   # Global npm CLIs installed via Volta. Bump a version here to upgrade it;
   # each is a semver range that npm itself resolves and satisfies in place.
+  #
+  # setup/windows.sh carries this same list -- Windows cannot evaluate Nix, so
+  # there is nothing for it to import. Bump both together. The same goes for
+  # axiAmbientContextTools, goPackages and secretEnvVars below.
   globalNpmPackages = [
     "@earendil-works/pi-coding-agent@^0.83.0" # https://www.npmjs.com/package/@earendil-works/pi-coding-agent
     "gh-axi@^0.1.29"                          # https://www.npmjs.com/package/gh-axi
@@ -186,18 +190,11 @@ in
     };
   };
 
-  programs.starship = {
-    enable = true;
-    settings = {
-      add_newline = false;
-      format = "$directory$git_branch$git_status$cmd_duration$line_break$character";
-      character = {
-        success_symbol = "[❯](purple)";
-        error_symbol = "[❯](red)";
-      };
-      cmd_duration.format = "[$duration]($style) ";
-    };
-  };
+  # No `settings` here on purpose: those would be rendered into a read-only
+  # store file, and Windows has no way to evaluate them. The prompt config is a
+  # tracked starship.toml symlinked below instead, so one file serves both
+  # platforms and stays editable in place.
+  programs.starship.enable = true;
 
   # Edit-in-place: the real file stays in my repo, ~/.config just points at it.
   home.file = {
@@ -205,6 +202,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${dotfiles}/home/.agents/skills";
     ".config/wezterm".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfiles}/home/.config/wezterm";
+    ".config/starship.toml".source =
+      config.lib.file.mkOutOfStoreSymlink "${dotfiles}/home/.config/starship.toml";
     ".config/nvim".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfiles}/home/.config/nvim";
     ".config/herdr".source =

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+# Windows only. Git for Windows' /etc/profile sources ~/.bash_profile for a
+# login shell and stops there, and WezTerm starts bash as a login shell, so
+# this is the entry point on that path.
+#
+# Nothing real lives here: keeping it all in ~/.bashrc means a non-login
+# interactive shell -- `bash` inside a shell, an agent hook, a subshell an
+# editor spawns -- gets exactly the same environment.
+
+# shellcheck source=home/.bashrc
+[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -1,0 +1,150 @@
+# shellcheck shell=bash
+# Windows only. The peer of `programs.zsh` in home.nix.
+#
+# HO-243 makes bash the shell on Windows -- it is what Git for Windows ships
+# and what WezTerm launches there -- so this file carries what home.nix's zsh
+# block carries on macOS: PATH, session variables, the prompt, completions for
+# the custom commands, secret loading and the aliases.
+#
+# Symlinked to ~/.bashrc by setup/windows.sh, so edits here take effect in the
+# next shell with no rebuild.
+#
+# Where a zsh feature has no bash equivalent, setup/windows-parity.md records
+# the decision rather than leaving a silent gap.
+
+# ---------------------------------------------------------------------------
+# PATH
+#
+# Re-added idempotently rather than appended once: a shell that inherits a PATH
+# from a long-lived parent (a herdr pane, an agent harness) must still resolve
+# the custom commands. Same reasoning as home.nix's initContent loop.
+# ---------------------------------------------------------------------------
+for _dir in "$HOME/go/bin" "${VOLTA_HOME:-$HOME/.volta}/bin" "$HOME/.local/bin"; do
+  case ":$PATH:" in
+  *":$_dir:"*) ;;
+  *) PATH="$_dir:$PATH" ;;
+  esac
+done
+unset _dir
+export PATH
+
+# ---------------------------------------------------------------------------
+# Session variables (home.nix's home.sessionVariables)
+#
+# No SSH_AUTH_SOCK here on purpose. On macOS it points at 1Password's agent
+# socket; on Windows 1Password serves the OpenSSH agent named pipe instead,
+# which Git for Windows' own ssh cannot speak. .gitconfig-windows routes git
+# through the native ssh.exe, which finds that pipe with no variable set.
+# ---------------------------------------------------------------------------
+export EDITOR="nvim"
+export REPO_HOME="$HOME/developer/repos"
+export VOLTA_HOME="${VOLTA_HOME:-$HOME/.volta}"
+
+# Everything in this environment hooks agents through bash scripts, and Claude
+# Code on Windows will not run one until it is told where bash lives.
+# setup/windows.sh sets this in the Windows user environment, so this is only
+# the fallback for a shell started before setup ran. Probed rather than
+# hard-coded: a per-user Git install lives somewhere else entirely.
+if [ -z "${CLAUDE_CODE_GIT_BASH_PATH:-}" ]; then
+  for _root in "${ProgramW6432:-}" "${ProgramFiles:-}" "${LOCALAPPDATA:-}\\Programs"; do
+    [ -n "$_root" ] || continue
+    if [ -f "$(cygpath -u "$_root" 2>/dev/null)/Git/bin/bash.exe" ]; then
+      export CLAUDE_CODE_GIT_BASH_PATH="$_root\\Git\\bin\\bash.exe"
+      break
+    fi
+  done
+  unset _root
+fi
+
+# Everything below is for interactive shells only.
+case $- in
+*i*) ;;
+*) return ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+if command -v starship >/dev/null 2>&1; then
+  eval "$(starship init bash)"
+fi
+
+# ---------------------------------------------------------------------------
+# History and line editing
+#
+# The closest bash gets to zsh-autosuggestions without pulling in ble.sh: Up
+# and Down search history for what has already been typed instead of walking it
+# blindly. Ctrl-F stays readline's forward-char, which is the same keystroke
+# that accepts a suggestion on macOS.
+# ---------------------------------------------------------------------------
+HISTSIZE=10000
+HISTFILESIZE=20000
+HISTCONTROL=ignoreboth
+shopt -s histappend
+shopt -s checkwinsize
+
+bind '"\e[A": history-search-backward'
+bind '"\e[B": history-search-forward'
+
+# oh-my-zsh's colored-man-pages plugin, done with what less already supports.
+export LESS_TERMCAP_md=$'\e[1;36m'  # bold -> cyan
+export LESS_TERMCAP_me=$'\e[0m'
+export LESS_TERMCAP_us=$'\e[1;32m'  # underline -> green
+export LESS_TERMCAP_ue=$'\e[0m'
+export LESS_TERMCAP_so=$'\e[1;33;44m' # search match
+export LESS_TERMCAP_se=$'\e[0m'
+
+# ---------------------------------------------------------------------------
+# Completions
+#
+# The same bash `complete -F` scripts macOS loads into zsh through bashcompinit;
+# here they just source. setup/windows.sh links the repo directory to
+# ~/.config/bash/bin-completion.
+# ---------------------------------------------------------------------------
+if [ -d "$HOME/.config/bash/bin-completion" ]; then
+  for _completion in "$HOME/.config/bash/bin-completion"/*; do
+    # shellcheck disable=SC1090  # one file per custom command, resolved at runtime
+    [ -f "$_completion" ] && . "$_completion"
+  done
+  unset _completion
+fi
+
+# ---------------------------------------------------------------------------
+# Secrets
+#
+# ~/.env is untracked; setup/windows.sh stubs every required key into it.
+# `set -a` exports what it defines, so child processes -- agents, MCP servers --
+# inherit them.
+# ---------------------------------------------------------------------------
+if [ -f "$HOME/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091  # untracked, machine-local
+  . "$HOME/.env"
+  set +a
+fi
+
+# Say so, every shell, until each stubbed secret actually has a value. Keep the
+# list in step with secretEnvVars in home.nix and setup/windows.sh.
+_secret_vars=(
+  CONTEXT7_API_KEY # mcp.json: context7 headers
+)
+_missing_secrets=""
+for _var in "${_secret_vars[@]}"; do
+  if [ -z "${!_var:-}" ]; then
+    _missing_secrets="${_missing_secrets:+$_missing_secrets, }$_var"
+  fi
+done
+if [ -n "$_missing_secrets" ]; then
+  echo "⚠  Unset secrets in ~/.env: $_missing_secrets" >&2
+  echo "   Set them there before using tooling that needs them." >&2
+fi
+unset _missing_secrets _secret_vars _var
+
+# ---------------------------------------------------------------------------
+# Aliases (home.nix's shellAliases)
+# ---------------------------------------------------------------------------
+alias ..="cd .."
+alias add="git add ."
+alias m="git switch main"
+alias cc="claude --dangerously-skip-permissions"
+alias co="codex --full-auto"

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -123,22 +123,34 @@ if [ -f "$HOME/.env" ]; then
   set +a
 fi
 
-# Say so, every shell, until each stubbed secret actually has a value. Keep the
-# list in step with secretEnvVars in home.nix and setup/windows.sh.
-_secret_vars=(
-  CONTEXT7_API_KEY # mcp.json: context7 headers
-)
-_missing_secrets=""
-for _var in "${_secret_vars[@]}"; do
-  if [ -z "${!_var:-}" ]; then
-    _missing_secrets="${_missing_secrets:+$_missing_secrets, }$_var"
+# Say so, every shell, until each stubbed secret actually has a value. The keys
+# are read out of ~/.env rather than listed here, so the required-secret list
+# stays declared in the two places that actually stub it: secretEnvVars in
+# home.nix and SECRET_ENV_VARS in setup/windows.sh. The file was just sourced
+# under `set -a`, so the environment is what says whether a key has a value --
+# which also honours one exported from somewhere else.
+if [ -f "$HOME/.env" ]; then
+  _missing_secrets=""
+  while IFS= read -r _line; do
+    case "$_line" in
+    '' | '#'*) continue ;;
+    esac
+    _var="${_line%%=*}"
+    # Not a `KEY=` line at all, or not a usable variable name.
+    [ "$_var" != "$_line" ] || continue
+    case "$_var" in
+    *[!A-Za-z0-9_]*) continue ;;
+    esac
+    if [ -z "${!_var:-}" ]; then
+      _missing_secrets="${_missing_secrets:+$_missing_secrets, }$_var"
+    fi
+  done <"$HOME/.env"
+  if [ -n "$_missing_secrets" ]; then
+    echo "⚠  Unset secrets in ~/.env: $_missing_secrets" >&2
+    echo "   Set them there before using tooling that needs them." >&2
   fi
-done
-if [ -n "$_missing_secrets" ]; then
-  echo "⚠  Unset secrets in ~/.env: $_missing_secrets" >&2
-  echo "   Set them there before using tooling that needs them." >&2
+  unset _missing_secrets _line _var
 fi
-unset _missing_secrets _secret_vars _var
 
 # ---------------------------------------------------------------------------
 # Aliases (home.nix's shellAliases)

--- a/home/.config/starship.toml
+++ b/home/.config/starship.toml
@@ -1,0 +1,16 @@
+# Prompt configuration, shared by both platforms.
+#
+# Tracked here rather than declared as `programs.starship.settings` in home.nix
+# so Windows gets the same prompt: nothing on that side can evaluate Nix. Both
+# platforms symlink this file to ~/.config/starship.toml, so edits take effect
+# in the next shell with no rebuild.
+
+add_newline = false
+format = "$directory$git_branch$git_status$cmd_duration$line_break$character"
+
+[character]
+success_symbol = "[❯](purple)"
+error_symbol = "[❯](red)"
+
+[cmd_duration]
+format = "[$duration]($style) "

--- a/home/.config/wezterm/wezterm.lua
+++ b/home/.config/wezterm/wezterm.lua
@@ -12,6 +12,45 @@ config.macos_window_background_blur = 50
 config.hide_tab_bar_if_only_one_tab = true
 config.window_decorations = "RESIZE"
 
+-- Windows: bash, not PowerShell.
+--
+-- WezTerm's default on Windows is PowerShell, but this environment is bash all
+-- the way down -- the custom commands, the agent hooks and ~/.bashrc all assume
+-- it -- so point the default program at Git for Windows' bash. `-l` makes it a
+-- login shell, which is what gets /etc/profile -> ~/.bash_profile -> ~/.bashrc
+-- read and lands the shell in $HOME.
+--
+-- Git's own installer picks one of these locations depending on whether it was
+-- a machine-wide or per-user install, so take the first that exists rather than
+-- hard-coding one and breaking on the other.
+if wezterm.target_triple:find("windows") then
+	-- Built by appending rather than as a literal: any of these can be unset,
+	-- and a nil inside a table constructor puts a hole in the list that ipairs
+	-- stops at, silently skipping every candidate after it.
+	local roots = {}
+	for _, name in ipairs({ "ProgramW6432", "ProgramFiles", "ProgramFiles(x86)" }) do
+		local value = os.getenv(name)
+		if value and value ~= "" then
+			table.insert(roots, value)
+		end
+	end
+	local localappdata = os.getenv("LOCALAPPDATA")
+	if localappdata and localappdata ~= "" then
+		-- Where a per-user (non-elevated) Git install lands.
+		table.insert(roots, localappdata .. "\\Programs")
+	end
+
+	for _, root in ipairs(roots) do
+		local bash = root .. "\\Git\\bin\\bash.exe"
+		local handle = io.open(bash, "r")
+		if handle then
+			handle:close()
+			config.default_prog = { bash, "-l" }
+			break
+		end
+	end
+end
+
 -- Dim unfocused windows so the focused one is obvious at a glance.
 local UNFOCUSED_FOREGROUND_TEXT_HSB = { hue = 1.0, saturation = 0.25, brightness = 0.45 }
 local UNFOCUSED_WINDOW_BACKGROUND_OPACITY = 0.62

--- a/home/.gitconfig-windows
+++ b/home/.gitconfig-windows
@@ -1,8 +1,15 @@
 [core]
-	sshCommand = ssh.exe
+	# Windows' own OpenSSH, by absolute path.
+	#
+	# Not a bare `ssh.exe`: Git Bash puts Git's bundled /usr/bin ahead of the
+	# Windows directories, so that would resolve to Git's own ssh -- and only
+	# the native client can reach 1Password's agent, which listens on the
+	# \\.\pipe\openssh-ssh-agent named pipe rather than a unix socket.
+	# https://developer.1password.com/docs/ssh/get-started/
+	sshCommand = C:/Windows/System32/OpenSSH/ssh.exe
 [gpg "ssh"]
-	# 1Password generates this path per-machine: open the SSH key in
-	# 1Password for Windows, "Configure Commit Signing" -> "Configure for
-	# Windows Subsystem for Linux (WSL)", and paste the value it gives you.
-	# See https://developer.1password.com/docs/ssh/integrations/wsl/
-	program =
+	# No `program` here on purpose. 1Password's signer lives under
+	# %LOCALAPPDATA%, whose path embeds this machine's username, so
+	# setup/windows.sh resolves it and writes it into ~/.gitconfig.local --
+	# untracked, alongside the signing key, the same split .gitconfig already
+	# uses for anything machine-specific.

--- a/home/.gitconfig-windows
+++ b/home/.gitconfig-windows
@@ -6,6 +6,9 @@
 	# the native client can reach 1Password's agent, which listens on the
 	# \\.\pipe\openssh-ssh-agent named pipe rather than a unix socket.
 	# https://developer.1password.com/docs/ssh/get-started/
+	#
+	# That client is an optional Windows feature, so setup/windows.sh step 13
+	# installs it (Add-WindowsCapability OpenSSH.Client) and warns if it cannot.
 	sshCommand = C:/Windows/System32/OpenSSH/ssh.exe
 [gpg "ssh"]
 	# No `program` here on purpose. 1Password's signer lives under

--- a/home/.pi/agent/hook/session-start.sh
+++ b/home/.pi/agent/hook/session-start.sh
@@ -9,8 +9,11 @@
 # fail the hook or block the session from starting.
 
 # Warm up the axi tool binaries so their first real invocation is fast.
+# Through $VOLTA_HOME rather than a hard-coded ~/.volta: both platforms put it
+# there, but a hook can run without the shell's environment, and Volta's own
+# default on Windows is %LOCALAPPDATA%\Volta.
 for tool in gh-axi chrome-devtools-axi quota-axi npm-axi lavish-axi tasks-axi; do
-  "$HOME/.volta/bin/$tool" --version >/dev/null 2>&1 || true
+  "${VOLTA_HOME:-$HOME/.volta}/bin/$tool" --version >/dev/null 2>&1 || true
 done
 
 # `no-mistakes init` is idempotent (refreshes an existing gate rather than

--- a/home/.ssh/config-windows
+++ b/home/.ssh/config-windows
@@ -1,4 +1,11 @@
-# WSL doesn't need an IdentityAgent override here: agent access goes through
-# WSL's interop layer calling Windows' native ssh.exe/ssh-add.exe directly
-# (see git config core.sshCommand in .gitconfig-windows), not a Linux-side
-# agent socket. See https://developer.1password.com/docs/ssh/integrations/wsl/
+# Nothing OS-specific is needed on Windows, but the file has to exist: the
+# tracked ~/.ssh/config Includes ~/.ssh/config-os unconditionally.
+#
+# No IdentityAgent override, unlike macOS. 1Password's Windows agent listens on
+# \\.\pipe\openssh-ssh-agent, which is exactly where Windows' native ssh.exe
+# looks by default -- and .gitconfig-windows routes git through that client.
+# https://developer.1password.com/docs/ssh/get-started/
+#
+# One file serves both clients here: Git Bash's $HOME is %USERPROFILE%, so
+# ~/.ssh/config is the same file C:\Users\<you>\.ssh\config that the native
+# ssh.exe reads.

--- a/home/bin/aup
+++ b/home/bin/aup
@@ -1,6 +1,20 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if [ -z "$1" ]; then
   echo "Usage: aup <port>"
   exit 1
 fi
-lsof -nP -i4TCP:"$1" | grep LISTEN
+
+if command -v lsof >/dev/null 2>&1; then
+  lsof -nP -i4TCP:"$1" | grep LISTEN
+else
+  # Windows has no lsof. netstat -ano carries the same facts (local address,
+  # state, owning pid) and tasklist turns the pid into a process name, which is
+  # the column lsof output is actually read for.
+  netstat -ano |
+    awk -v port=":$1" '$1 == "TCP" && $2 ~ port "$" && $4 == "LISTENING" { print $2, $4, $5 }' |
+    while read -r local_addr state pid; do
+      name="$(MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" /NH /FO CSV 2>/dev/null |
+        head -n1 | cut -d, -f1 | tr -d '"')"
+      printf '%s\t%s\t%s\t%s\n' "${name:-?}" "$pid" "$state" "$local_addr"
+    done
+fi

--- a/home/bin/aup
+++ b/home/bin/aup
@@ -10,11 +10,14 @@ else
   # Windows has no lsof. netstat -ano carries the same facts (local address,
   # state, owning pid) and tasklist turns the pid into a process name, which is
   # the column lsof output is actually read for.
-  netstat -ano |
+  # Both are native programs, so their CRLF line endings have to go before the
+  # parse: a \r left on the pid makes the tasklist filter match nothing, and
+  # one left on the name mangles the printed line.
+  netstat -ano | tr -d '\r' |
     awk -v port=":$1" '$1 == "TCP" && $2 ~ port "$" && $4 == "LISTENING" { print $2, $4, $5 }' |
     while read -r local_addr state pid; do
       name="$(MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" /NH /FO CSV 2>/dev/null |
-        head -n1 | cut -d, -f1 | tr -d '"')"
+        tr -d '\r' | head -n1 | cut -d, -f1 | tr -d '"')"
       printf '%s\t%s\t%s\t%s\n' "${name:-?}" "$pid" "$state" "$local_addr"
     done
 fi

--- a/home/bin/db
+++ b/home/bin/db
@@ -1,3 +1,3 @@
-#!/usr/bin/env zsh
-git push origin --delete $1
-git branch -D $1
+#!/usr/bin/env bash
+git push origin --delete "$1"
+git branch -D "$1"

--- a/home/bin/denv
+++ b/home/bin/denv
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$1" ]; then
   export DOCKER_HOST="$1"
 fi

--- a/home/bin/dka
+++ b/home/bin/dka
@@ -1,2 +1,8 @@
-#!/usr/bin/env zsh
-docker kill ${=$(docker ps -q)}
+#!/usr/bin/env bash
+containers="$(docker ps -q)"
+if [ -z "$containers" ]; then
+  echo "No running containers"
+  exit 0
+fi
+# shellcheck disable=SC2086  # deliberate word splitting: one argument per container id
+docker kill $containers

--- a/home/bin/fa
+++ b/home/bin/fa
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git fetch --all

--- a/home/bin/firstmate
+++ b/home/bin/firstmate
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 cd "$HOME/developer/firstmate" && exec cc

--- a/home/bin/gco
+++ b/home/bin/gco
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git checkout "$@"

--- a/home/bin/glg
+++ b/home/bin/glg
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative

--- a/home/bin/gnxt
+++ b/home/bin/gnxt
@@ -1,9 +1,9 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 # @description Navigate to the next commit in git history relative to a given branch
 # @arg $1 string Branch reference to navigate from (e.g., main, branch1)
 # @example gnxt main
 if ! [ -z "$1" ]; then
-  git checkout $1~$(($(git rev-list HEAD..$1 | wc -l) - 1))
+  git checkout "$1~$(($(git rev-list "HEAD..$1" | wc -l) - 1))"
 else
   echo "No branch ref provided; e.g., \$(gnxt main)."
 fi

--- a/home/bin/gwta
+++ b/home/bin/gwta
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
 WORKTREE_DEST_DIR=$1
 WORKTREE_REF=$2

--- a/home/bin/kaup
+++ b/home/bin/kaup
@@ -5,12 +5,21 @@ if [ -z "$1" ]; then
 fi
 
 if command -v lsof >/dev/null 2>&1; then
+  HAVE_LSOF=1
+else
+  HAVE_LSOF=0
+fi
+
+if [ "$HAVE_LSOF" -eq 1 ]; then
   PIDS="$(lsof -nP -i4TCP:"$1" | grep LISTEN | awk '{print $2}' | sort -u)"
 else
   # Windows: no lsof, and Git Bash's kill works on its own process ids rather
   # than native Windows ones, so both halves of this come from Windows' own
-  # tools. See aup for the same netstat parse.
-  PIDS="$(netstat -ano |
+  # tools. See aup for the same netstat parse. netstat is a native program, so
+  # its CRLF line endings would otherwise leave a \r on every pid and make
+  # taskkill fail. Note the taskkill error goes to stderr, so the kill would
+  # look like it worked.
+  PIDS="$(netstat -ano | tr -d '\r' |
     awk -v port=":$1" '$1 == "TCP" && $2 ~ port "$" && $4 == "LISTENING" { print $5 }' | sort -u)"
 fi
 
@@ -20,7 +29,7 @@ if [ -z "$PIDS" ]; then
 fi
 
 for pid in $PIDS; do
-  if command -v lsof >/dev/null 2>&1; then
+  if [ "$HAVE_LSOF" -eq 1 ]; then
     kill -9 "$pid"
   else
     MSYS_NO_PATHCONV=1 taskkill /F /PID "$pid" >/dev/null

--- a/home/bin/kaup
+++ b/home/bin/kaup
@@ -1,8 +1,29 @@
-#!/usr/bin/env zsh
-PID=$(lsof -nP -i4TCP:$1 | grep LISTEN | awk '{print $2}')
-if [ -z "$PID" ]; then
+#!/usr/bin/env bash
+if [ -z "$1" ]; then
+  echo "Usage: kaup <port>"
+  exit 1
+fi
+
+if command -v lsof >/dev/null 2>&1; then
+  PIDS="$(lsof -nP -i4TCP:"$1" | grep LISTEN | awk '{print $2}' | sort -u)"
+else
+  # Windows: no lsof, and Git Bash's kill works on its own process ids rather
+  # than native Windows ones, so both halves of this come from Windows' own
+  # tools. See aup for the same netstat parse.
+  PIDS="$(netstat -ano |
+    awk -v port=":$1" '$1 == "TCP" && $2 ~ port "$" && $4 == "LISTENING" { print $5 }' | sort -u)"
+fi
+
+if [ -z "$PIDS" ]; then
   echo "No process listening on port $1"
   exit 1
 fi
-kill -9 ${=PID}
-echo "Killed process $PID listening on port $1"
+
+for pid in $PIDS; do
+  if command -v lsof >/dev/null 2>&1; then
+    kill -9 "$pid"
+  else
+    MSYS_NO_PATHCONV=1 taskkill /F /PID "$pid" >/dev/null
+  fi
+done
+echo "Killed process $(echo "$PIDS" | tr '\n' ' ')listening on port $1"

--- a/home/bin/lb
+++ b/home/bin/lb
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$1" ]; then
   git branch -a | grep "$1"
 else

--- a/home/bin/nb
+++ b/home/bin/nb
@@ -1,10 +1,10 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$2" ]; then
   git stash
-  git checkout $2
+  git checkout "$2"
   git pull --rebase
   git stash apply
 fi
-git checkout -b $1
-git push origin $1
+git checkout -b "$1"
+git push origin "$1"
 sb

--- a/home/bin/oproj
+++ b/home/bin/oproj
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
-code ${REPO_HOME}/$1
+#!/usr/bin/env bash
+code "${REPO_HOME}/$1"

--- a/home/bin/pmb
+++ b/home/bin/pmb
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git branch --merged master --no-color | grep -v '^[ *]*master$' | xargs git branch -d

--- a/home/bin/projs
+++ b/home/bin/projs
@@ -1,6 +1,7 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+# shellcheck disable=SC2010  # repo directories are plain names; the ls listing is the point
 if ! [ -z "$1" ]; then
-  ls ${REPO_HOME} | grep "$1"
+  ls "${REPO_HOME}" | grep "$1"
 else
-  ls ${REPO_HOME}
+  ls "${REPO_HOME}"
 fi

--- a/home/bin/pull
+++ b/home/bin/pull
@@ -1,9 +1,9 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$1" ]; then
   if ! [ -z "$2" ]; then
-    git pull --rebase $1 $2
+    git pull --rebase "$1" "$2"
   else
-    git pull --rebase origin $1
+    git pull --rebase origin "$1"
   fi
 else
   git pull --rebase

--- a/home/bin/push
+++ b/home/bin/push
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git push "$@"

--- a/home/bin/rba
+++ b/home/bin/rba
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git rebase --abort

--- a/home/bin/rbc
+++ b/home/bin/rbc
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git rebase --continue

--- a/home/bin/rbi
+++ b/home/bin/rbi
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git rebase -i "$@"

--- a/home/bin/rbs
+++ b/home/bin/rbs
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git rebase --skip

--- a/home/bin/rh
+++ b/home/bin/rh
@@ -1,9 +1,9 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$1" ]; then
   if ! [ -z "$2" ]; then
-    git reset --hard $1/$2
+    git reset --hard "$1/$2"
   else
-    git reset --hard $1
+    git reset --hard "$1"
   fi
 else
   git reset --hard

--- a/home/bin/rs
+++ b/home/bin/rs
@@ -1,9 +1,9 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$1" ]; then
   if ! [ -z "$2" ]; then
-    git reset --soft $1/$2
+    git reset --soft "$1/$2"
   else
-    git reset --soft $1
+    git reset --soft "$1"
   fi
 else
   git checkout .

--- a/home/bin/sb
+++ b/home/bin/sb
@@ -1,11 +1,11 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 if ! [ -z "$1" ]; then
   if ! [ -z "$2" ]; then
-    git branch --set-upstream-to=$1/$2
+    git branch --set-upstream-to="$1/$2"
   else
-    git branch --set-upstream-to=origin/$1
+    git branch --set-upstream-to="origin/$1"
   fi
 else
   currentBranch="$(git rev-parse --abbrev-ref HEAD)"
-  git branch --set-upstream-to=origin/${currentBranch}
+  git branch --set-upstream-to="origin/${currentBranch}"
 fi

--- a/home/bin/st
+++ b/home/bin/st
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git status

--- a/home/bin/stash
+++ b/home/bin/stash
@@ -1,2 +1,2 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 git stash "$@"

--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,7 @@ Anything that changes what is installed or configured needs a decision on both p
 | A Mac App Store app | `mas-apps.nix`, then re-run `setup/macOS.sh` (not `homebrew.masApps`) |
 | A global npm CLI | `globalNpmPackages` in `home.nix` and `GLOBAL_NPM_PACKAGES` in `setup/windows.sh` |
 | A Go CLI | `goPackages` in `home.nix` and `GO_PACKAGES` in `setup/windows.sh` (pinned to a release tag) |
-| A required secret | `secretEnvVars` in `home.nix`, `SECRET_ENV_VARS` in `setup/windows.sh`, and `_secret_vars` in `home/.bashrc`; it is stubbed into `~/.env` on the next rebuild |
+| A required secret | `secretEnvVars` in `home.nix` and `SECRET_ENV_VARS` in `setup/windows.sh`; it is stubbed into `~/.env` on the next rebuild, and the shells warn about it until it has a value |
 | A custom command | Drop a bash executable in `home/bin/`; it is picked up automatically on both platforms |
 | A pi extension | `packages` in `home/.pi/agent/settings.json` |
 | An agent skill | Add `home/.agents/skills/<name>/SKILL.md`; shared by pi and Claude Code |

--- a/readme.md
+++ b/readme.md
@@ -9,12 +9,11 @@ Everything is reproducible and version controlled. Configuration files are symli
 | Platform | Status |
 | --- | --- |
 | macOS on Apple Silicon (`aarch64-darwin`) | Supported |
+| Windows on x86_64, in Git for Windows' bash | Supported |
 | macOS on Intel | Not supported |
-| Windows / WSL | Not yet migrated |
+| WSL | Not supported (the Windows path is native, not WSL) |
 
 ## Install
-
-Requires macOS on Apple Silicon. Nothing else needs to be preinstalled; the setup script bootstraps Nix itself.
 
 ```bash
 git clone https://github.com/andrew-codes/devtools.git ~/developer/repos/devtools
@@ -22,7 +21,11 @@ cd ~/developer/repos/devtools
 ./setup.sh
 ```
 
-`setup.sh` detects the OS and architecture and dispatches to the matching platform script -- currently just `setup/macOS.sh` for macOS on Apple Silicon. On any other platform it prints what was detected and exits rather than attempting an install.
+`setup.sh` detects the OS and architecture and dispatches to the matching platform script: `setup/macOS.sh` on Apple Silicon, `setup/windows.sh` on Windows. On any other platform it prints what was detected and exits rather than attempting an install.
+
+On macOS nothing needs to be preinstalled; the setup script bootstraps Nix itself. On Windows, run it from Git for Windows' bash -- you already have that, since it is what cloned this repo.
+
+### macOS
 
 The macOS script:
 
@@ -35,13 +38,33 @@ The macOS script:
 
 Sign in to the Mac App Store before step 5; `mas` cannot authenticate on its own, and it prompts for an admin password when it has real work to do. App Store apps are acquired here, as the real user in the real login session, rather than through nix-darwin's `homebrew.masApps` -- that option runs outside the per-user launchd session `mas` needs, so it would fail on every rebuild. `homebrew.masApps` is deliberately left empty.
 
+### Windows
+
+Nix does not run natively on Windows, so `setup/windows.sh` carries by itself what nix-darwin and home-manager carry on macOS. It:
+
+1. Ensures the latest Git for Windows, upgrading only when one is available.
+2. Ensures native symlinks are allowed, enabling Developer Mode (one UAC prompt) if they are not. Every dotfile is a symlink into this repo, exactly as on macOS.
+3. Symlinks the repo to `~/.dotfiles`.
+4. Installs applications and CLI tools with `winget`.
+5. Installs the two things winget cannot deliver -- the Hack Nerd Font and `kubeseal` -- from their pinned upstream releases.
+6. Installs Node via Volta and the global agent CLIs, then the Go CLIs.
+7. Links every dotfile, stubs `~/.env`, merges Claude Code's settings and MCP servers, installs the AXI session hooks, applies the Windows system defaults, and wires up 1Password commit signing.
+
+Expect UAC prompts during the winget step. Re-running is safe and is the supported way to apply later changes.
+
+**[`setup/windows-parity.md`](setup/windows-parity.md) is the map**: every macOS package, config and system default, with what Windows does about it -- implemented, deliberately skipped with a reason, or deferred. Read it before adding anything to either platform.
+
+Two consequences worth knowing up front: the shell is **bash**, not zsh, and WezTerm launches it by default; and the `twg` CLI has no Windows build at all, so agents have no Atlassian tooling there.
+
 ### Applying Changes Later
 
-After the first install, rebuild with either:
+After the first install, rebuild from anywhere with:
 
 ```bash
-devtools-rebuild    # from anywhere, symlinked onto PATH
+devtools-rebuild    # symlinked onto PATH on both platforms
 ```
+
+On macOS that runs `rebuild.sh` (`darwin-rebuild switch`); on Windows it re-runs `setup/windows.sh`, which is idempotent.
 
 ### Required Manual Steps
 
@@ -49,11 +72,11 @@ Two files hold values that are specific to a single machine or are secret, so th
 
 | File | Purpose |
 | --- | --- |
-| `~/.env` | Secrets. Auto-created with every required key stubbed empty. zsh warns on every shell until each has a value. |
-| `~/.gitconfig.local` | This machine's git SSH signing key. Activation prints a reminder if missing. |
+| `~/.env` | Secrets. Auto-created with every required key stubbed empty. The shell warns on every startup until each has a value. |
+| `~/.gitconfig.local` | This machine's git SSH signing key. Setup prints a reminder if missing. On Windows it also holds the resolved 1Password signer path. |
 | `~/.ssh/config.local` | Optional. Personal SSH hosts, included from the tracked `~/.ssh/config`. |
 
-> **Note:** Homebrew uses `onActivation.cleanup = "none"`, so packages installed outside this repo are left alone on rebuild. Existing files at a managed path must be moved aside before the first activation; home-manager will not clobber them.
+> **Note:** Homebrew uses `onActivation.cleanup = "none"`, so packages installed outside this repo are left alone on rebuild. Existing files at a managed path must be moved aside before the first activation; home-manager will not clobber them. `setup/windows.sh` moves them aside itself, to `<name>.bak`.
 
 ---
 
@@ -61,14 +84,15 @@ Two files hold values that are specific to a single machine or are secret, so th
 
 ### Shell
 
-- **zsh** with autosuggestions (`Ctrl-F` to accept), syntax highlighting, and a [starship](https://starship.rs/) prompt showing directory, git branch/status, and command duration.
+- **zsh on macOS** with autosuggestions (`Ctrl-F` to accept) and syntax highlighting; **bash on Windows** (`home/.bashrc`), where Up/Down search history in place of autosuggestions and there is no syntax highlighting.
+- A [starship](https://starship.rs/) prompt on both, showing directory, git branch/status, and command duration. Its config is a tracked `home/.config/starship.toml` shared by both platforms.
 - **Secret loading.** `~/.env` is sourced and exported at startup so child processes (agents, MCP servers) inherit it.
-- **Completions.** Tab-completion for the custom commands below, loaded through `bashcompinit`.
+- **Completions.** Tab-completion for the custom commands below. They are bash `complete -F` scripts, loaded natively by bash and through `bashcompinit` by zsh.
 - Aliases: `..`, `add`, `m`, `cc`, `co`.
 
 ### Custom Commands
 
-Scripts in `home/bin/` are symlinked individually into `~/.local/bin`.
+Scripts in `home/bin/` are symlinked individually into `~/.local/bin`. They are bash, so they run on both platforms.
 
 | Group | Commands |
 | --- | --- |
@@ -80,27 +104,31 @@ Scripts in `home/bin/` are symlinked individually into `~/.local/bin`.
 
 ### CLI Toolchain
 
-Installed from nixpkgs: `ripgrep`, `fd`, `eza`, `fzf`, `jq`, `yq`, `lazygit`, `neovim`, `uv`, `shfmt`, `gh`, `kubectl`, `kubeseal`, `fluxcd`, `terraform`, `ansible`, `volta`, plus the Hack Nerd Font.
+Installed from nixpkgs on macOS: `ripgrep`, `fd`, `eza`, `fzf`, `jq`, `yq`, `lazygit`, `neovim`, `uv`, `shfmt`, `gh`, `kubectl`, `kubeseal`, `fluxcd`, `terraform`, `ansible`, `volta`, plus the Hack Nerd Font.
+
+The same set comes from `winget` on Windows, except `ansible` (no Windows control node), `kubeseal` and the Hack Nerd Font (no winget package -- taken from their pinned upstream releases). `setup/windows-parity.md` lists every id.
 
 Node.js is managed by [Volta](https://volta.sh/), which pins each global CLI to the Node version it was installed with, so changing your default Node version never breaks an installed tool.
 
 ### Applications
 
-Installed via Homebrew and the Mac App Store:
+Installed via Homebrew and the Mac App Store on macOS, via `winget` on Windows:
 
-| App | Purpose |
-| --- | --- |
-| [WezTerm](https://wezterm.org/) | Terminal emulator |
-| [tmux](https://github.com/tmux/tmux) | Terminal multiplexer |
-| [1Password](https://1password.com/) + CLI | Passwords, SSH agent, commit signing |
-| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Containers |
-| [Raycast](https://raycast.com/) | Launcher (replaces Spotlight) |
-| [Lens](https://k8slens.dev/) | Kubernetes IDE |
-| [Claude Code](https://www.anthropic.com/claude-code) | Anthropic coding agent |
-| [herdr](https://herdr.dev/) | Agent session multiplexer |
-| [gitops](https://github.com/weaveworks/weave-gitops) / [telepresence](https://www.telepresence.io/) | Kubernetes workflow CLIs |
-| [Logi Options+](https://www.logitech.com/software/logi-options-plus.html) | Logitech device configuration |
-| Dynamic Wallpaper Library | Wallpapers (Mac App Store) |
+| App | Purpose | Windows |
+| --- | --- | --- |
+| [WezTerm](https://wezterm.org/) | Terminal emulator | Yes, defaulting to bash |
+| [1Password](https://1password.com/) + CLI | Passwords, SSH agent, commit signing | Yes |
+| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Containers | Yes |
+| [Lens](https://k8slens.dev/) | Kubernetes IDE | Yes |
+| [Claude Code](https://www.anthropic.com/claude-code) | Anthropic coding agent | Yes |
+| [Logi Options+](https://www.logitech.com/software/logi-options-plus.html) | Logitech device configuration | Yes |
+| [Raycast](https://raycast.com/) | Launcher (replaces Spotlight) | [PowerToys](https://learn.microsoft.com/windows/powertoys/) Run instead |
+| [tmux](https://github.com/tmux/tmux) | Terminal multiplexer | No -- WezTerm's own panes |
+| [herdr](https://herdr.dev/) | Agent session multiplexer | Not yet; Windows is an upstream beta |
+| [gitops](https://github.com/weaveworks/weave-gitops) / [telepresence](https://www.telepresence.io/) | Kubernetes workflow CLIs | No |
+| Dynamic Wallpaper Library | Wallpapers (Mac App Store) | No -- macOS only |
+
+Every one of these decisions, with its reason, is in [`setup/windows-parity.md`](setup/windows-parity.md).
 
 ### AI Agent Harness
 
@@ -140,6 +168,8 @@ Because those commands write into `~/.claude/settings.json`, that one file is ap
 
 **Atlassian tooling.** Jira and Confluence are reached through the [`twg` CLI](https://developer.atlassian.com/cloud/twg-cli/), not an MCP server, and `home/AGENTS.md` instructs every agent to use it and never the Rovo MCP. A CLI keeps the tool definitions out of the model's context until they are actually needed, and one authenticated binary serves every harness. `twg` is pinned to an exact version in `home.nix` and installed during activation; run `twg login` once by hand afterwards, since its OAuth flow is interactive and cannot run inside a rebuild.
 
+Atlassian ships no Windows build -- its installer refuses to run anywhere but macOS and Linux -- so on Windows there is no `twg`. The rule in `home/AGENTS.md` already covers that case: agents say so and stop rather than falling back to an MCP.
+
 **Shared agent context.** A single `home/AGENTS.md` is symlinked to both `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`, so every harness follows the same instructions. Global agent skills live in `home/.agents/skills/`.
 
 ### Git and SSH
@@ -152,19 +182,23 @@ Git config is layered so shared settings stay tracked while machine-specific and
   -> ~/.gitconfig.local   machine-specific signing key, untracked
 ```
 
-SSH follows the same pattern: a tracked `~/.ssh/config` includes `~/.ssh/config-os` (the 1Password `IdentityAgent`) and an untracked `~/.ssh/config.local` for personal hosts.
+`~/.gitconfig-os` points at `home/.gitconfig-macos` or `home/.gitconfig-windows` depending on the platform. SSH follows the same pattern: a tracked `~/.ssh/config` includes `~/.ssh/config-os` and an untracked `~/.ssh/config.local` for personal hosts.
 
-1Password acts as the SSH agent (`SSH_AUTH_SOCK`) and signs commits, with the offered key declared in `home/.config/1Password/ssh/agent.toml`.
+1Password acts as the SSH agent and signs commits, with the offered key declared in `home/.config/1Password/ssh/agent.toml`. On macOS git reaches it through the `SSH_AUTH_SOCK` socket; on Windows it listens on the OpenSSH agent named pipe, which only the native `ssh.exe` can speak, so `.gitconfig-windows` sets `core.sshCommand` to it by absolute path.
 
-### macOS System Defaults
+### System Defaults
 
-Dark mode, fast key repeat, auto-hiding dock and menu bar, all file extensions visible, Finder in list view, no desktop icons, tap-to-click disabled, and Spotlight indexing turned off since Raycast replaces it.
+**macOS:** dark mode, fast key repeat, auto-hiding dock and menu bar, all file extensions visible, Finder in list view, no desktop icons, tap-to-click disabled, and Spotlight indexing turned off since Raycast replaces it.
+
+**Windows:** dark mode, fast key repeat, all file extensions visible, no desktop icons, tap-to-click disabled. Taskbar auto-hide, Explorer's default view and Windows Search are deliberately left alone -- `setup/windows-parity.md` says why for each.
 
 ### Edit-in-Place Configs
 
-These are symlinked out of the repo, so edits apply immediately with no rebuild: WezTerm, Neovim, herdr, pi (settings, models, theme, extensions, hooks), and the global gitignore.
+These are symlinked out of the repo on both platforms, so edits apply immediately with no rebuild: WezTerm, Neovim, starship, herdr, bash (`.bashrc`), pi (settings, models, theme, extensions, hooks), and the global gitignore.
 
 Claude Code's `settings.json` is the exception: the AXI `setup hooks` commands write into it, and their writes follow symlinks, so it is merged in during activation and needs a rebuild instead.
+
+Windows needs native symlinks for any of this, which is why `setup/windows.sh` turns on Developer Mode before it links anything.
 
 ---
 
@@ -177,10 +211,13 @@ home.nix               User level: packages, zsh, dotfile symlinks, activation s
 mas-apps.nix           Mac App Store apps, applied by setup/macOS.sh (not by nix-darwin)
 setup.sh               Detects OS/arch, dispatches to the matching setup/ script
 setup/macOS.sh         First-time bootstrap for macOS on Apple Silicon
-rebuild.sh             Apply changes (also on PATH as devtools-rebuild)
+setup/windows.sh       Setup and rebuild for Windows; stands in for nix-darwin and home-manager
+setup/windows-parity.md  Every macOS entry mapped to its Windows decision
+rebuild.sh             Apply changes on macOS (also on PATH as devtools-rebuild)
 home/                  Every tracked dotfile, symlinked into place
   bin/                 Custom commands -> ~/.local/bin
-  bin-completion/      Their zsh completions
+  bin-completion/      Their bash completions
+  .bashrc              The Windows shell, peer of programs.zsh in home.nix
   .pi/agent/           pi harness config
   .config/mcp/         MCP server definitions
   .agents/skills/      Global agent skills
@@ -188,15 +225,18 @@ home/                  Every tracked dotfile, symlinked into place
 
 ## Customizing
 
+Anything that changes what is installed or configured needs a decision on both platforms, and a row in `setup/windows-parity.md`.
+
 | To add | Edit |
 | --- | --- |
-| A CLI from nixpkgs | `home.packages` in `home.nix` |
-| A GUI app or Homebrew formula | `homebrew.casks` / `brews` in `configuration.nix` |
+| A CLI from nixpkgs | `home.packages` in `home.nix`, and `WINGET_PACKAGES` in `setup/windows.sh` |
+| A GUI app or Homebrew formula | `homebrew.casks` / `brews` in `configuration.nix`, and `WINGET_PACKAGES` |
 | A Mac App Store app | `mas-apps.nix`, then re-run `setup/macOS.sh` (not `homebrew.masApps`) |
-| A global npm CLI | `globalNpmPackages` in `home.nix` (semver range, upgrades in place) |
-| A Go CLI | `goPackages` in `home.nix` (pinned to a release tag) |
-| A required secret | `secretEnvVars` in `home.nix`; it is stubbed into `~/.env` on the next rebuild |
-| A custom command | Drop an executable in `home/bin/`; it is picked up automatically |
+| A global npm CLI | `globalNpmPackages` in `home.nix` and `GLOBAL_NPM_PACKAGES` in `setup/windows.sh` |
+| A Go CLI | `goPackages` in `home.nix` and `GO_PACKAGES` in `setup/windows.sh` (pinned to a release tag) |
+| A required secret | `secretEnvVars` in `home.nix`, `SECRET_ENV_VARS` in `setup/windows.sh`, and `_secret_vars` in `home/.bashrc`; it is stubbed into `~/.env` on the next rebuild |
+| A custom command | Drop a bash executable in `home/bin/`; it is picked up automatically on both platforms |
 | A pi extension | `packages` in `home/.pi/agent/settings.json` |
 | An agent skill | Add `home/.agents/skills/<name>/SKILL.md`; shared by pi and Claude Code |
 | A subagent | Add `home/.pi/agent/agents/<name>.md`; shared by pi and Claude Code |
+| The prompt | `home/.config/starship.toml` (shared, edit-in-place) |

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Nix does not run natively on Windows, so `setup/windows.sh` carries by itself wh
 4. Installs applications and CLI tools with `winget`.
 5. Installs the two things winget cannot deliver -- the Hack Nerd Font and `kubeseal` -- from their pinned upstream releases.
 6. Installs Node via Volta and the global agent CLIs, then the Go CLIs.
-7. Links every dotfile, stubs `~/.env`, merges Claude Code's settings and MCP servers, installs the AXI session hooks, applies the Windows system defaults, and wires up 1Password commit signing.
+7. Links every dotfile, stubs `~/.env`, merges Claude Code's settings and MCP servers, installs the AXI session hooks, applies the Windows system defaults, installs the Windows OpenSSH client if it is missing (git needs it to reach 1Password's agent), and wires up 1Password commit signing.
 
 Expect UAC prompts during the winget step. Re-running is safe and is the supported way to apply later changes.
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 os_type="$OSTYPE"
 arch_type="$(uname -m)"
 [[ $OSTYPE == darwin* ]] && os_type="macos"
+# Git for Windows' bash reports msys; a Cygwin shell reports cygwin. Both are
+# running on Windows, and setup/windows.sh checks for the same pair itself.
+[[ $OSTYPE == msys* || $OSTYPE == cygwin* ]] && os_type="windows"
 
 echo "==> Detected: $os_type / $arch_type"
 
@@ -14,6 +17,10 @@ if [[ $os_type == "macos" && $arch_type == "arm64" ]]; then
   exec "$SCRIPT_DIR/setup/macOS.sh"
 fi
 
+if [[ $os_type == "windows" && $arch_type == "x86_64" ]]; then
+  exec "$SCRIPT_DIR/setup/windows.sh"
+fi
+
 echo "Error: Unsupported platform: $os_type / $arch_type" >&2
-echo "Currently supported: macOS on Apple Silicon (arm64)." >&2
+echo "Currently supported: macOS on Apple Silicon (arm64), Windows on x86_64." >&2
 exit 1

--- a/setup/windows-parity.md
+++ b/setup/windows-parity.md
@@ -36,6 +36,7 @@ native Windows.
 | `setup.sh` dispatch | same | **Implemented.** `./setup.sh` detects `msys`/`cygwin` and execs `setup/windows.sh`. |
 | Mac App Store apps (`mas-apps.nix`, `mas`) | - | **Skipped.** No Mac App Store on Windows. The one entry (Dynamic Wallpaper Library) is a wallpaper app, not dev tooling. |
 | Homebrew + `nix-homebrew` | winget | **Implemented.** winget is the default; the two exceptions below say why. |
+| - (macOS ships `ssh`) | Windows OpenSSH Client capability | **Implemented** (step 13). `.gitconfig-windows` pins `core.sshCommand` to `%SystemRoot%\System32\OpenSSH\ssh.exe` because only the native client reaches 1Password's named-pipe agent, and that client is an optional feature. The step installs it with `Add-WindowsCapability` (the inbox feature, not the winget package, which lands elsewhere) and warns if it still is not there. |
 
 ## Applications (`configuration.nix` casks and brews)
 
@@ -51,7 +52,7 @@ native Windows.
 | `raycast` | `Microsoft.PowerToys` | **Implemented, substituted.** Raycast ships no winget package. PowerToys Run is the equivalent keystroke launcher. |
 | `tmux` | - | **Skipped.** Git for Windows ships no tmux and it needs a POSIX pty. WezTerm's own tabs and panes, plus herdr, cover the use. |
 | `mas` | - | **Skipped.** macOS-only by definition. |
-| `herdr` | - | **Deferred.** Upstream publishes macOS and Linux binaries only; Windows is a beta whose sole install path is an unpinned `irm https://herdr.dev/install.ps1 \| iex`. That is below the bar this repo holds remote installers to (see the `twgVersion` comment in `home.nix`), so the script prints the command instead of running it. Its config is linked either way. |
+| `herdr` | - | **Deferred.** Upstream publishes macOS and Linux binaries only; Windows is a beta whose sole install path is an unpinned `irm https://herdr.dev/install.ps1 \| iex`. That is below the bar this repo holds remote installers to (see the `twgVersion` comment in `home.nix`), so the script prints the command instead of running it. Its `~/.config/herdr` config is linked either way. |
 | `weaveworks/tap/gitops` | - | **Deferred.** No winget package, and Weaveworks wound down in 2024. `flux` covers the maintained part of that workflow. |
 | `datawire/blackbird/telepresence` | - | **Deferred.** No winget package; the Windows install needs an elevated daemon service, so run Ambassador's own installer on demand. |
 
@@ -125,7 +126,7 @@ config in this repo takes effect with no rebuild - the same contract
 | `~/.config/wezterm`, `~/.agents/skills`, `~/.claude/{skills,agents,CLAUDE.md}`, `~/.codex/AGENTS.md`, `~/.pi/agent/*`, `~/.gitconfig`, `~/.gitignore`, `~/.ssh/config`, `~/.config/mcp/mcp.json`, `~/.config/1Password/ssh/agent.toml` | identical paths | **Implemented.** |
 | `~/.config/nvim` | `%LOCALAPPDATA%\nvim` | **Implemented, moved.** Neovim resolves `stdpath('config')` there on Windows. |
 | `~/.config/zsh/bin-completion` | `~/.config/bash/bin-completion` | **Implemented, moved.** bash, not zsh. |
-| `~/.config/herdr` | `~/.config/herdr` **and** `%APPDATA%\herdr` | **Implemented, both.** herdr's Windows config path is undocumented upstream; both point at the same tracked file. |
+| `~/.config/herdr` | `~/.config/herdr` only | **Implemented, single link.** herdr's Windows config path is undocumented upstream, but the `%APPDATA%\herdr` candidate is deliberately not linked: `%APPDATA%\<app>` is where a Windows app writes runtime state, and those writes would follow the symlink into this tracked public checkout. If herdr turns out to read `%APPDATA%`, copy the config there rather than linking it. |
 | `~/.gitconfig-os` | `home/.gitconfig-windows` | **Implemented.** Same include scheme as macOS. |
 | `~/.ssh/config-os` | `home/.ssh/config-windows` | **Implemented.** Same include scheme as macOS. |
 | `~/.gitconfig.local` (untracked signing key) | same, plus `gpg.ssh.program` | **Implemented.** The 1Password signer path embeds the username, so the script resolves and writes it there rather than tracking it. |
@@ -157,7 +158,9 @@ priority order:
    dependency, Go needs a C toolchain that Git for Windows does not ship.
 3. **pi on Windows.** `@earendil-works/pi-coding-agent` installs from npm, but
    it is untested here.
-4. **herdr's config path**, if herdr is installed by hand - see above.
+4. **herdr's config path**, if herdr is installed by hand. Only `~/.config/herdr`
+   is linked; if the Windows build reads `%APPDATA%\herdr` instead, copy the
+   config there - never link it, or herdr's own state writes land in this repo.
 5. **1Password `agent.toml`** names the `andrew-mbp` key item. Add this
    machine's item to `home/.config/1Password/ssh/agent.toml`.
 6. **`core.editor = zed --wait`** in the shared `~/.gitconfig` assumes Zed, and

--- a/setup/windows-parity.md
+++ b/setup/windows-parity.md
@@ -36,7 +36,7 @@ native Windows.
 | `setup.sh` dispatch | same | **Implemented.** `./setup.sh` detects `msys`/`cygwin` and execs `setup/windows.sh`. |
 | Mac App Store apps (`mas-apps.nix`, `mas`) | - | **Skipped.** No Mac App Store on Windows. The one entry (Dynamic Wallpaper Library) is a wallpaper app, not dev tooling. |
 | Homebrew + `nix-homebrew` | winget | **Implemented.** winget is the default; the two exceptions below say why. |
-| - (macOS ships `ssh`) | Windows OpenSSH Client capability | **Implemented** (step 13). `.gitconfig-windows` pins `core.sshCommand` to `%SystemRoot%\System32\OpenSSH\ssh.exe` because only the native client reaches 1Password's named-pipe agent, and that client is an optional feature. The step installs it with `Add-WindowsCapability` (the inbox feature, not the winget package, which lands elsewhere) and warns if it still is not there. |
+| - (macOS ships `ssh`) | Windows OpenSSH Client capability | **Implemented** (step 13). `.gitconfig-windows` pins `core.sshCommand` to the literal `C:/Windows/System32/OpenSSH/ssh.exe` (git config takes no environment expansion) because only the native client reaches 1Password's named-pipe agent, and that client is an optional feature. The step installs it with `Add-WindowsCapability` (the inbox feature, not the winget package, which lands elsewhere) and warns if it still is not there. |
 
 ## Applications (`configuration.nix` casks and brews)
 

--- a/setup/windows-parity.md
+++ b/setup/windows-parity.md
@@ -1,0 +1,167 @@
+# Windows parity inventory
+
+Every piece of software and configuration the macOS path installs, mapped to
+what the Windows path does about it. Nothing is left unstated: each row is
+**Implemented**, **Skipped** (with the reason it does not apply), or
+**Deferred** (applicable, but not done here, with what is in the way).
+
+The macOS side is `setup/macOS.sh` + `configuration.nix` + `home.nix` +
+`mas-apps.nix` + `home/`. The Windows side is `setup/windows.sh` alone: Nix has
+no native Windows support, so one script carries what nix-darwin and
+home-manager carry over there.
+
+When you add something to the macOS path, add a row here.
+
+## Target
+
+Native Windows on x86_64 with **Git for Windows' bash** as the shell -- not
+WSL. That is what HO-243 asks for ("bash should be the default shell for
+wezterm", and the repo is cloned with Git for Windows before setup runs).
+
+`home/.gitconfig-windows` and `home/.ssh/config-windows` predate this work and
+were written for WSL. They keep their names and their place in the existing
+`~/.gitconfig` -> `~/.gitconfig-os` include scheme; only their contents moved to
+native Windows.
+
+## Platform machinery
+
+| macOS | Windows | Decision |
+| --- | --- | --- |
+| Determinate Nix (`setup/macOS.sh` step 1) | - | **Skipped.** Nix has no native Windows support; it runs only under WSL, which is not this target. |
+| nix-darwin (`configuration.nix`) | `setup/windows.sh` steps 4 and 12 | **Implemented** directly: winget for packages, `reg.exe` for system defaults. |
+| home-manager (`home.nix`) | `setup/windows.sh` steps 6-11 | **Implemented** directly: symlinks, activation-equivalent steps, secrets file. |
+| `flake.nix` / `flake.lock` pinning | pinned version constants in `setup/windows.sh` | **Implemented**, weaker. winget resolves "latest" per package; only the two non-winget downloads are version-pinned. |
+| `~/.dotfiles` symlink | same | **Implemented** (step 3). |
+| `rebuild.sh` -> `devtools-rebuild` | `setup/windows.sh` -> `devtools-rebuild` | **Implemented.** Re-running the setup script *is* the rebuild; it is idempotent by design. |
+| `setup.sh` dispatch | same | **Implemented.** `./setup.sh` detects `msys`/`cygwin` and execs `setup/windows.sh`. |
+| Mac App Store apps (`mas-apps.nix`, `mas`) | - | **Skipped.** No Mac App Store on Windows. The one entry (Dynamic Wallpaper Library) is a wallpaper app, not dev tooling. |
+| Homebrew + `nix-homebrew` | winget | **Implemented.** winget is the default; the two exceptions below say why. |
+
+## Applications (`configuration.nix` casks and brews)
+
+| macOS | Windows | Decision |
+| --- | --- | --- |
+| `wezterm` | `wez.wezterm` | **Implemented.** Defaults to Git Bash on Windows - see "Shell" below. |
+| `1password` | `AgileBits.1Password` | **Implemented.** |
+| `1password-cli` | `AgileBits.1Password.CLI` | **Implemented.** |
+| `docker-desktop` | `Docker.DockerDesktop` | **Implemented.** |
+| `lens` | `Mirantis.Lens` | **Implemented.** |
+| `logi-options+` | `Logitech.OptionsPlus` | **Implemented.** |
+| `claude-code` | `Anthropic.ClaudeCode` | **Implemented.** |
+| `raycast` | `Microsoft.PowerToys` | **Implemented, substituted.** Raycast ships no winget package. PowerToys Run is the equivalent keystroke launcher. |
+| `tmux` | - | **Skipped.** Git for Windows ships no tmux and it needs a POSIX pty. WezTerm's own tabs and panes, plus herdr, cover the use. |
+| `mas` | - | **Skipped.** macOS-only by definition. |
+| `herdr` | - | **Deferred.** Upstream publishes macOS and Linux binaries only; Windows is a beta whose sole install path is an unpinned `irm https://herdr.dev/install.ps1 \| iex`. That is below the bar this repo holds remote installers to (see the `twgVersion` comment in `home.nix`), so the script prints the command instead of running it. Its config is linked either way. |
+| `weaveworks/tap/gitops` | - | **Deferred.** No winget package, and Weaveworks wound down in 2024. `flux` covers the maintained part of that workflow. |
+| `datawire/blackbird/telepresence` | - | **Deferred.** No winget package; the Windows install needs an elevated daemon service, so run Ambassador's own installer on demand. |
+
+## CLI toolchain (`home.packages`)
+
+| macOS | Windows | Decision |
+| --- | --- | --- |
+| `ripgrep` | `BurntSushi.ripgrep.MSVC` | **Implemented.** |
+| `fd` | `sharkdp.fd` | **Implemented.** |
+| `eza` | `eza-community.eza` | **Implemented.** |
+| `fzf` | `junegunn.fzf` | **Implemented.** |
+| `jq` | `jqlang.jq` | **Implemented.** |
+| `yq` | `MikeFarah.yq` | **Implemented.** |
+| `lazygit` | `JesseDuffield.lazygit` | **Implemented.** |
+| `neovim` | `Neovim.Neovim` | **Implemented.** |
+| `uv` | `astral-sh.uv` | **Implemented.** |
+| `shfmt` | `mvdan.shfmt` | **Implemented.** |
+| `gh` | `GitHub.cli` | **Implemented.** |
+| `kubectl` | `Kubernetes.kubectl` | **Implemented.** |
+| `fluxcd` | `FluxCD.Flux` | **Implemented.** |
+| `terraform` | `Hashicorp.Terraform` | **Implemented.** |
+| `volta` | `Volta.Volta` | **Implemented.** `VOLTA_HOME` is forced to `~/.volta` so one path works on both platforms. |
+| `kubeseal` | GitHub release binary | **Implemented, fallback.** No winget package at all. The release is a single static binary, pinned by version in the script. |
+| `nerd-fonts.hack` | GitHub release archive | **Implemented, fallback.** winget only carries `SourceFoundry.HackFonts`, which is plain Hack without the patched glyphs starship and eza need. |
+| `ansible` | - | **Skipped.** Ansible does not support Windows as a control node. |
+| `go` (activation-only on macOS) | `GoLang.Go` | **Implemented**, and installed for real: the Go CLIs below need a toolchain on PATH. |
+
+## Agent harness
+
+| macOS | Windows | Decision |
+| --- | --- | --- |
+| `globalNpmPackages` via Volta's npm (`pi`, `gh-axi`, `chrome-devtools-axi`, `quota-axi`, `npm-axi`, `lavish-axi`, `tasks-axi`) | same list, same `--ignore-scripts` | **Implemented** (step 6). The list is duplicated from `home.nix` because Nix cannot evaluate here; bump both together. |
+| `goPackages` (`no-mistakes`, `treehouse`) | `go install`, same pinned tags | **Implemented** (step 7). If either needs cgo, `go install` fails and the script says which C toolchain to add. |
+| pi extensions (`home/.pi/agent/settings.json`) | same file, linked | **Implemented.** pi installs them itself from the linked settings. |
+| `~/.claude/settings.json` merge | same jq merge | **Implemented** (step 10), for the same reason: the AXI hook installers write into that file and their writes follow symlinks. |
+| `~/.claude.json` MCP merge | same jq merge | **Implemented** (step 10). |
+| AXI `setup hooks` | same | **Implemented** (step 11). |
+| `twg` CLI | - | **Skipped, with consequences.** Atlassian's installer hard-fails on anything that is not Darwin or Linux ("Only macOS and Linux are supported"), and there is no Windows build. `home/AGENTS.md` tells agents to use `twg` and never an Atlassian MCP, so on Windows agents have **no** Atlassian tooling - they should say so and stop, which is what that rule already prescribes. |
+| Claude Code hooks running bash | `CLAUDE_CODE_GIT_BASH_PATH` | **Implemented.** Every hook here is a bash script; Claude Code on Windows needs to be told where bash is. Set in the user environment and in `~/.bashrc`. |
+
+## Shell
+
+macOS runs zsh; Windows runs bash, because that is what Git for Windows ships
+and what HO-243 requires WezTerm to launch. `home/.bashrc` is the peer of
+`programs.zsh` in `home.nix`.
+
+| macOS | Windows | Decision |
+| --- | --- | --- |
+| zsh as login shell (`users.users.<user>.shell`) | bash via WezTerm's `default_prog` | **Implemented** in `home/.config/wezterm/wezterm.lua`, which resolves Git's `bash.exe` and starts it as a login shell. |
+| `programs.starship` | `Starship.Starship` + `starship init bash` in `~/.bashrc` | **Implemented.** The prompt settings moved out of `home.nix` into a tracked `home/.config/starship.toml` that both platforms symlink, so one file gives both the same prompt. |
+| zsh autosuggestions | readline history-search on Up/Down | **Implemented, weaker.** Full ghost-text needs `ble.sh`, a large third-party runtime; history-search covers the common case with what readline already has. |
+| zsh syntax highlighting | - | **Skipped.** No bash equivalent without `ble.sh`. |
+| oh-my-zsh `colored-man-pages` | `LESS_TERMCAP_*` | **Implemented.** |
+| oh-my-zsh `sudo`, `pj`, `docker`, `yarn`, `encode64`, `eza`, `fluxcd`, `gh`, `git-escape-magic` | - | **Skipped.** These are zsh plugins; the binaries they wrap are all installed, only the aliases and completions they add are missing. |
+| `shellAliases` (`..`, `add`, `m`, `cc`, `co`) | same aliases in `~/.bashrc` | **Implemented.** |
+| `~/.env` sourcing + unset-secret warning | same in `~/.bashrc` | **Implemented.** |
+| `home.sessionPath` (`~/.local/bin`, `~/.volta/bin`, `~/go/bin`) | same, re-added idempotently in `~/.bashrc` | **Implemented.** The *Windows* user PATH is deliberately left alone; winget and Volta manage their own entries. |
+| `EDITOR`, `REPO_HOME`, `VOLTA_HOME` | same | **Implemented.** |
+| `SSH_AUTH_SOCK` -> 1Password socket | - | **Skipped.** 1Password on Windows serves the OpenSSH agent named pipe, which Git's bundled ssh cannot speak. `.gitconfig-windows` routes git through the native `ssh.exe`, which finds the pipe with no variable set. |
+| `bin-completion` via `bashcompinit` | sourced natively from `~/.config/bash/bin-completion` | **Implemented.** They were already bash `complete -F` scripts. |
+| `home/bin/*` custom commands | same files, linked into `~/.local/bin` | **Implemented.** Their shebangs moved from zsh to bash so they run on both platforms; `aup` and `kaup` gained `netstat`/`taskkill` branches because Windows has no `lsof`. |
+
+## Dotfiles and paths
+
+All linked with native symlinks (step 2 ensures Developer Mode), so editing a
+config in this repo takes effect with no rebuild - the same contract
+`mkOutOfStoreSymlink` gives on macOS.
+
+| Path | Windows | Decision |
+| --- | --- | --- |
+| `~/.config/wezterm`, `~/.agents/skills`, `~/.claude/{skills,agents,CLAUDE.md}`, `~/.codex/AGENTS.md`, `~/.pi/agent/*`, `~/.gitconfig`, `~/.gitignore`, `~/.ssh/config`, `~/.config/mcp/mcp.json`, `~/.config/1Password/ssh/agent.toml` | identical paths | **Implemented.** |
+| `~/.config/nvim` | `%LOCALAPPDATA%\nvim` | **Implemented, moved.** Neovim resolves `stdpath('config')` there on Windows. |
+| `~/.config/zsh/bin-completion` | `~/.config/bash/bin-completion` | **Implemented, moved.** bash, not zsh. |
+| `~/.config/herdr` | `~/.config/herdr` **and** `%APPDATA%\herdr` | **Implemented, both.** herdr's Windows config path is undocumented upstream; both point at the same tracked file. |
+| `~/.gitconfig-os` | `home/.gitconfig-windows` | **Implemented.** Same include scheme as macOS. |
+| `~/.ssh/config-os` | `home/.ssh/config-windows` | **Implemented.** Same include scheme as macOS. |
+| `~/.gitconfig.local` (untracked signing key) | same, plus `gpg.ssh.program` | **Implemented.** The 1Password signer path embeds the username, so the script resolves and writes it there rather than tracking it. |
+| `~/.claude/settings.json` | merged, not linked | **Implemented.** Same reason as macOS. |
+
+## System defaults (`system.defaults`)
+
+| macOS | Windows | Decision |
+| --- | --- | --- |
+| `AppleInterfaceStyle = Dark` | `AppsUseLightTheme` / `SystemUsesLightTheme` = 0 | **Implemented.** |
+| `AppleShowAllExtensions` | `HideFileExt` = 0 | **Implemented.** |
+| `finder.CreateDesktop = false` | `HideIcons` = 1 | **Implemented.** |
+| `KeyRepeat` / `InitialKeyRepeat` | `KeyboardSpeed` = 31, `KeyboardDelay` = 0 | **Implemented.** |
+| `trackpad.Clicking = false` | `PrecisionTouchPad\TapsEnabled` = 0 | **Implemented.** No-op on a machine with no precision touchpad. |
+| `dock.autohide` | - | **Deferred.** Taskbar auto-hide lives inside the `StuckRects3` binary blob; editing it by hand means rewriting an opaque byte and restarting Explorer. Not worth the fragility - toggle it in Settings. |
+| `_HIHideMenuBar` | - | **Skipped.** Windows has no menu bar. |
+| `finder.FXPreferredViewStyle = "Nlsv"` | - | **Deferred.** Explorer stores view style per folder in its Bags; there is no clean global equivalent. |
+| Spotlight indexing off (`mdutil -i off`) | - | **Skipped.** The macOS line exists because Raycast replaces Spotlight. Windows Search also backs the Start menu, so disabling it costs more than it saves. |
+
+## Known gaps and things to check on the real machine
+
+Everything in this PR was written on macOS and could not be executed. In
+priority order:
+
+1. **Git upgrade under a live Git Bash.** Step 1 may fail to replace files this
+   very session has open. The script detects that and prints the manual command;
+   confirm which branch it takes.
+2. **`go install` and cgo.** If `no-mistakes` or `treehouse` pull a cgo
+   dependency, Go needs a C toolchain that Git for Windows does not ship.
+3. **pi on Windows.** `@earendil-works/pi-coding-agent` installs from npm, but
+   it is untested here.
+4. **herdr's config path**, if herdr is installed by hand - see above.
+5. **1Password `agent.toml`** names the `andrew-mbp` key item. Add this
+   machine's item to `home/.config/1Password/ssh/agent.toml`.
+6. **`core.editor = zed --wait`** in the shared `~/.gitconfig` assumes Zed, and
+   `home/bin/oproj` calls `code`. Neither editor is installed by the macOS path
+   either, so neither is installed here - but on Windows there is no fallback
+   `zed` on PATH at all, so `git commit` without `-m` will fail until one is
+   installed by hand.

--- a/setup/windows.sh
+++ b/setup/windows.sh
@@ -1,0 +1,658 @@
+#!/usr/bin/env bash
+#
+# First-time bootstrap and re-runnable rebuild for Windows.
+#
+# Peer of setup/macOS.sh, but it carries more. On macOS, nix-darwin and
+# home-manager own package installs, dotfile symlinks, activation scripts and
+# system defaults, so setup/macOS.sh only has to bootstrap them. Nix has no
+# native Windows support, so everything configuration.nix and home.nix do over
+# there is done directly here.
+#
+# setup/windows-parity.md maps every macOS entry to what this script does --
+# or deliberately does not do -- about it. Keep it in step with this file.
+#
+# Runs in Git for Windows' bash. Re-running is the supported way to apply
+# changes: every step is a no-op once it has been done, and this file is
+# symlinked onto PATH as `devtools-rebuild`, the same name macOS uses for
+# rebuild.sh.
+
+set -euo pipefail
+
+# The repo root, one level up from this script's own directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# What gets installed.
+#
+# These lists are this file's answer to configuration.nix (homebrew.brews and
+# .casks) and home.nix (home.packages, globalNpmPackages, goPackages,
+# secretEnvVars). The declaration lives here; the steps below are only the
+# mechanism.
+#
+# The npm, Go and secret lists are duplicated from home.nix on purpose -- Nix
+# cannot evaluate on Windows, so there is nothing to import. Bump both when you
+# bump either; home.nix carries a comment pointing back here.
+# ---------------------------------------------------------------------------
+
+# winget ids, each verified against the microsoft/winget-pkgs manifests. The
+# comment on each line names the macOS entry it stands in for.
+WINGET_PACKAGES=(
+  Git.Git                 # kept current by Step 1; listed so a machine that
+                          # somehow lacks it still gets it
+  wez.wezterm             # cask wezterm
+  AgileBits.1Password     # cask 1password
+  AgileBits.1Password.CLI # cask 1password-cli
+  Docker.DockerDesktop    # cask docker-desktop
+  Mirantis.Lens           # cask lens
+  Logitech.OptionsPlus    # cask logi-options+
+  Anthropic.ClaudeCode    # cask claude-code
+  Microsoft.PowerToys     # stands in for cask raycast; PowerToys Run is the
+                          # keystroke launcher, and Raycast ships no Windows
+                          # package on winget
+  BurntSushi.ripgrep.MSVC # pkgs.ripgrep
+  sharkdp.fd              # pkgs.fd
+  eza-community.eza       # pkgs.eza
+  junegunn.fzf            # pkgs.fzf
+  jqlang.jq               # pkgs.jq
+  MikeFarah.yq            # pkgs.yq
+  JesseDuffield.lazygit   # pkgs.lazygit
+  Neovim.Neovim           # pkgs.neovim
+  astral-sh.uv            # pkgs.uv
+  mvdan.shfmt             # pkgs.shfmt
+  GitHub.cli              # pkgs.gh
+  Kubernetes.kubectl      # pkgs.kubectl
+  FluxCD.Flux             # pkgs.fluxcd
+  Hashicorp.Terraform     # pkgs.terraform
+  Volta.Volta             # pkgs.volta
+  GoLang.Go               # macOS gets go only inside home-manager activation;
+                          # here the Go CLIs need a real toolchain on PATH
+  Starship.Starship       # programs.starship
+)
+
+# Pinned, because winget has no package for either. See Step 5.
+HACK_NERD_FONT_VERSION="3.5.0" # https://github.com/ryanoasis/nerd-fonts/releases
+KUBESEAL_VERSION="0.38.4"      # https://github.com/bitnami-labs/sealed-secrets/releases
+
+# Mirrors globalNpmPackages in home.nix.
+GLOBAL_NPM_PACKAGES=(
+  "@earendil-works/pi-coding-agent@^0.83.0"
+  "gh-axi@^0.1.29"
+  "chrome-devtools-axi@^0.1.28"
+  "quota-axi@^0.1.17"
+  "npm-axi@^0.1.1"
+  "lavish-axi@^0.1.45"
+  "tasks-axi@^0.2.5"
+)
+
+# Mirrors axiAmbientContextTools in home.nix.
+AXI_AMBIENT_CONTEXT_TOOLS=(lavish-axi tasks-axi)
+
+# Mirrors goPackages in home.nix.
+GO_PACKAGES=(
+  "github.com/kunchenguid/no-mistakes/cmd/no-mistakes@v1.41.2"
+  "github.com/kunchenguid/treehouse@v1.8.0"
+)
+
+# Mirrors secretEnvVars in home.nix.
+SECRET_ENV_VARS=(
+  CONTEXT7_API_KEY # mcp.json: context7 headers
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Anything worth telling the captain about at the end rather than losing in
+# several hundred lines of install output.
+WARNINGS=()
+
+warn() {
+  WARNINGS+=("$1")
+  echo "    WARNING: $1" >&2
+}
+
+# Windows programs get their arguments mangled by the MSYS runtime: a bare
+# `/f` looks like an absolute POSIX path and is rewritten to a drive path.
+# MSYS_NO_PATHCONV=1 turns that off for one command, which is what every
+# reg.exe / cmd.exe call below needs.
+win() {
+  MSYS_NO_PATHCONV=1 "$@"
+}
+
+# `test -x` does not know about the implicit .exe suffix that MSYS applies when
+# it actually runs a command, so check for both spellings.
+have_file() {
+  [ -f "$1" ] || [ -f "$1.exe" ] || [ -f "$1.cmd" ]
+}
+
+# The Git Bash launcher, as a Windows path. Not `command -v bash`: that resolves
+# to Git\usr\bin\bash.exe, the raw MSYS shell, where Git\bin\bash.exe is the
+# wrapper that sets MSYSTEM and the right PATH. Which prefix it lives under
+# depends on whether Git was installed machine-wide or per-user.
+git_bash_path() {
+  local root candidate
+  for root in "${ProgramW6432:-}" "${ProgramFiles:-}" "${LOCALAPPDATA:-}\\Programs"; do
+    [ -n "$root" ] || continue
+    candidate="$(cygpath -u "$root" 2>/dev/null)/Git/bin/bash.exe"
+    if [ -f "$candidate" ]; then
+      cygpath -w "$candidate"
+      return 0
+    fi
+  done
+  cygpath -w "$(command -v bash)"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+case "${OSTYPE:-}" in
+msys* | cygwin*) ;;
+*)
+  echo "Error: setup/windows.sh has to run from Git for Windows' bash." >&2
+  echo "Detected OSTYPE='${OSTYPE:-unset}'." >&2
+  exit 1
+  ;;
+esac
+
+if ! command -v winget >/dev/null 2>&1; then
+  echo "Error: winget is not on PATH." >&2
+  echo "It ships with Windows 11 as App Installer. Install or update it from" >&2
+  echo "the Microsoft Store ('App Installer'), then re-run this script." >&2
+  exit 1
+fi
+
+LOCALAPPDATA_DIR="$(cygpath -u "${LOCALAPPDATA:?LOCALAPPDATA is not set}")"
+APPDATA_DIR="$(cygpath -u "${APPDATA:?APPDATA is not set}")"
+
+TMP_ROOT="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+echo "==> Step 1: latest Git for Windows"
+# The ticket's one hard requirement about Git: ensure the latest is installed
+# on every run, without reinstalling when it is already current.
+#
+# winget's exit status is not the signal to read here. `winget upgrade` exits
+# non-zero both when there is nothing to do and when something went wrong, so
+# judge on git's own version instead and only inspect the log to tell those two
+# cases apart.
+GIT_VERSION_BEFORE="$(git --version 2>/dev/null || echo "unknown")"
+GIT_UPGRADE_LOG="$TMP_ROOT/git-upgrade.log"
+winget upgrade --id Git.Git --exact --silent \
+  --accept-package-agreements --accept-source-agreements \
+  --disable-interactivity >"$GIT_UPGRADE_LOG" 2>&1 || true
+GIT_VERSION_AFTER="$(git --version 2>/dev/null || echo "unknown")"
+
+if [ "$GIT_VERSION_BEFORE" != "$GIT_VERSION_AFTER" ]; then
+  echo "    upgraded: $GIT_VERSION_BEFORE -> $GIT_VERSION_AFTER"
+elif grep -qiE "no (applicable|available|newer|installed)" "$GIT_UPGRADE_LOG"; then
+  # "no installed package" is in that list because a Git installed outside
+  # winget is invisible to `winget upgrade`. Step 4 installs Git.Git for real in
+  # that case, which registers it, so the next run of this step can upgrade it.
+  echo "    already current ($GIT_VERSION_AFTER)"
+else
+  # Most likely cause: the installer could not replace files that this very
+  # Git Bash session has open. Not fatal -- the rest of the setup is still
+  # worth doing -- but say so loudly and repeat it in the summary.
+  tail -n 5 "$GIT_UPGRADE_LOG" >&2 || true
+  warn "Git for Windows may be out of date ($GIT_VERSION_AFTER). Close every Git Bash and WezTerm window, then run: winget upgrade --id Git.Git -e"
+fi
+
+echo "==> Step 2: native symlink capability"
+# Every dotfile below is a symlink into this repo, which is what makes editing
+# a config here take effect with no rebuild -- the same contract home.nix's
+# mkOutOfStoreSymlink gives on macOS. Windows only lets an unprivileged user
+# create symlinks when Developer Mode is on, so establish that first and fail
+# early rather than half-way through linking.
+#
+# MSYS would otherwise silently fall back to copying files, which would break
+# edit-in-place and let a later run clobber edits; nativestrict makes it fail
+# instead.
+can_symlink() {
+  local probe="$TMP_ROOT/symlink-probe"
+  rm -rf "$probe" "$probe.link"
+  mkdir -p "$probe"
+  MSYS=winsymlinks:nativestrict ln -s "$probe" "$probe.link" 2>/dev/null
+}
+
+if can_symlink; then
+  echo "    already allowed"
+else
+  echo "    not allowed yet; enabling Developer Mode (expect one UAC prompt)"
+  DEV_MODE_PS1="$TMP_ROOT/enable-developer-mode.ps1"
+  cat >"$DEV_MODE_PS1" <<'PS1'
+$key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+New-Item -Path $key -Force | Out-Null
+Set-ItemProperty -Path $key -Name AllowDevelopmentWithoutDevLicense -Value 1 -Type DWord
+PS1
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
+    "Start-Process -Verb RunAs -Wait -FilePath powershell.exe -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$(cygpath -w "$DEV_MODE_PS1")'" \
+    >/dev/null 2>&1 || true
+
+  # The flag is read when CreateSymbolicLinkW is called, not at logon, so it
+  # takes effect for the very next attempt.
+  if can_symlink; then
+    echo "    enabled"
+  else
+    echo "Error: cannot create symbolic links." >&2
+    echo "Turn on Settings > System > For developers > Developer Mode (or run" >&2
+    echo "this script from an elevated Git Bash) and try again." >&2
+    exit 1
+  fi
+fi
+
+echo "==> Step 3: symlink this repo to ~/.dotfiles"
+# Same indirection macOS uses: every link below points through ~/.dotfiles, so
+# the recorded path is identical on both platforms and moving the checkout only
+# needs this one link repointed.
+DOTFILES="$HOME/.dotfiles"
+if [ -L "$DOTFILES" ]; then
+  rm -f "$DOTFILES"
+elif [ -e "$DOTFILES" ]; then
+  echo "Error: $DOTFILES exists and is not a symlink. Move it aside first." >&2
+  exit 1
+fi
+MSYS=winsymlinks:nativestrict ln -s "$SCRIPT_DIR" "$DOTFILES"
+
+# Now that ~/.dotfiles exists, define the linker the dotfile step uses.
+link() {
+  local target="$1" link_path="$2"
+  mkdir -p "$(dirname "$link_path")"
+
+  if [ -L "$link_path" ]; then
+    # Compare where it actually resolves rather than the stored string: MSYS
+    # records native symlinks with a Windows path, so the raw readlink output
+    # never matches the POSIX path handed in here.
+    if [ "$(readlink -f "$link_path" 2>/dev/null)" = "$(readlink -f "$target" 2>/dev/null)" ]; then
+      return 0
+    fi
+    rm -f "$link_path"
+  elif [ -e "$link_path" ]; then
+    # Something real is already there. Move it aside rather than destroy it --
+    # the same contract as home-manager.backupFileExtension = "bak" in
+    # flake.nix.
+    echo "    backing up $link_path -> $link_path.bak"
+    rm -rf "$link_path.bak"
+    mv "$link_path" "$link_path.bak"
+  fi
+
+  MSYS=winsymlinks:nativestrict ln -s "$target" "$link_path"
+}
+
+echo "==> Step 4: applications and CLI tools (winget)"
+# Install-if-missing, never force-upgrade. That matches macOS, where brew
+# bundle installs what is missing and leaves installed versions alone
+# (homebrew.onActivation.upgrade is off), and it is what keeps a re-run fast.
+for id in "${WINGET_PACKAGES[@]}"; do
+  if winget list --id "$id" --exact --accept-source-agreements >/dev/null 2>&1; then
+    echo "    $id (installed)"
+    continue
+  fi
+  echo "    $id (installing)"
+  if ! winget install --id "$id" --exact --silent \
+    --accept-package-agreements --accept-source-agreements \
+    --disable-interactivity; then
+    warn "winget could not install $id"
+  fi
+done
+
+# winget puts its shims in %LOCALAPPDATA%\Microsoft\WinGet\Links and adds that
+# directory to the *Windows* user PATH. This bash process inherited its PATH
+# long before any of that happened, so the rest of this run would not see the
+# tools it just installed. Go and Volta ship MSIs that add their own entries,
+# with the same problem.
+PROGRAM_FILES_DIR="$(cygpath -u "${ProgramFiles:-C:\\Program Files}")"
+for dir in \
+  "$LOCALAPPDATA_DIR/Microsoft/WinGet/Links" \
+  "$PROGRAM_FILES_DIR/Go/bin" \
+  "$PROGRAM_FILES_DIR/Volta" \
+  "$LOCALAPPDATA_DIR/Volta/bin"; do
+  if [ -d "$dir" ]; then
+    case ":$PATH:" in
+    *":$dir:"*) ;;
+    *) PATH="$dir:$PATH" ;;
+    esac
+  fi
+done
+export PATH
+
+echo "==> Step 5: tools winget cannot deliver"
+# winget first is the rule; these two are the exceptions, and each says why.
+
+# The Hack Nerd Font: winget carries SourceFoundry.HackFonts, which is plain
+# Hack without the patched glyphs. starship's prompt and eza's icons both need
+# the Nerd Font variant, so take it from the upstream release instead.
+FONT_DIR="$LOCALAPPDATA_DIR/Microsoft/Windows/Fonts"
+if compgen -G "$FONT_DIR/HackNerdFont-*.ttf" >/dev/null; then
+  echo "    Hack Nerd Font (installed)"
+else
+  echo "    Hack Nerd Font (installing v$HACK_NERD_FONT_VERSION)"
+  FONT_ZIP="$TMP_ROOT/Hack.zip"
+  FONT_EXTRACT="$TMP_ROOT/hack-nerd-font"
+  if curl -fsSL --retry 2 -o "$FONT_ZIP" \
+    "https://github.com/ryanoasis/nerd-fonts/releases/download/v${HACK_NERD_FONT_VERSION}/Hack.zip"; then
+    mkdir -p "$FONT_EXTRACT" "$FONT_DIR"
+    mkdir -p "$FONT_EXTRACT" "$FONT_DIR"
+    # Git Bash's tar cannot read zip archives; PowerShell's Expand-Archive is
+    # always present and can.
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
+      "Expand-Archive -LiteralPath '$(cygpath -w "$FONT_ZIP")' -DestinationPath '$(cygpath -w "$FONT_EXTRACT")' -Force" \
+      >/dev/null 2>&1 || true
+
+    FONTS_INSTALLED=0
+    for ttf in "$FONT_EXTRACT"/*.ttf; do
+      [ -f "$ttf" ] || continue
+      base="$(basename "$ttf")"
+      cp -f "$ttf" "$FONT_DIR/$base"
+      # Copying the file is enough for WezTerm, which scans the per-user font
+      # directory itself; the registry entry is what makes the font show up in
+      # every other Windows application.
+      win reg.exe add "HKCU\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts" \
+        /v "${base%.ttf} (TrueType)" /t REG_SZ \
+        /d "$(cygpath -w "$FONT_DIR/$base")" /f >/dev/null
+      FONTS_INSTALLED=$((FONTS_INSTALLED + 1))
+    done
+
+    if [ "$FONTS_INSTALLED" -eq 0 ]; then
+      warn "the Hack Nerd Font archive extracted no .ttf files; WezTerm will fall back to a system font"
+    else
+      echo "    installed $FONTS_INSTALLED font files"
+    fi
+  else
+    warn "could not download the Hack Nerd Font; WezTerm will fall back to a system font"
+  fi
+fi
+
+# kubeseal: no winget package at all, and the upstream release is a single
+# static binary, so drop it next to the other user-scoped commands.
+KUBESEAL_BIN="$HOME/.local/bin/kubeseal"
+if have_file "$KUBESEAL_BIN" && "$KUBESEAL_BIN" --version 2>/dev/null | grep -q "$KUBESEAL_VERSION"; then
+  echo "    kubeseal (installed)"
+else
+  echo "    kubeseal (installing v$KUBESEAL_VERSION)"
+  KUBESEAL_TGZ="$TMP_ROOT/kubeseal.tar.gz"
+  if curl -fsSL --retry 2 -o "$KUBESEAL_TGZ" \
+    "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-windows-amd64.tar.gz"; then
+    mkdir -p "$HOME/.local/bin"
+    # Never fatal: a changed archive layout must not take the whole setup down.
+    tar -xzf "$KUBESEAL_TGZ" -C "$HOME/.local/bin" kubeseal.exe ||
+      warn "kubeseal v$KUBESEAL_VERSION downloaded but kubeseal.exe was not where expected in the archive"
+  else
+    warn "could not download kubeseal v$KUBESEAL_VERSION"
+  fi
+fi
+
+echo "==> Step 6: Node toolchain and global agent CLIs"
+# Volta defaults to %LOCALAPPDATA%\Volta on Windows. Point it at ~/.volta
+# instead so one path works on both platforms -- home.nix, the shell configs
+# and the shared session-start hook all reach for $VOLTA_HOME/bin.
+VOLTA_HOME="$HOME/.volta"
+export VOLTA_HOME
+VOLTA_HOME_WIN="$(cygpath -w "$VOLTA_HOME")"
+CURRENT_VOLTA_HOME="$(powershell.exe -NoProfile -Command \
+  "[Environment]::GetEnvironmentVariable('VOLTA_HOME','User')" 2>/dev/null | tr -d '\r')"
+if [ "$CURRENT_VOLTA_HOME" != "$VOLTA_HOME_WIN" ]; then
+  # Windows-native processes (Volta's own shims, anything launched outside
+  # bash) read this from the user environment, not from ~/.bashrc.
+  win setx VOLTA_HOME "$VOLTA_HOME_WIN" >/dev/null
+  echo "    set user VOLTA_HOME=$VOLTA_HOME_WIN"
+fi
+PATH="$VOLTA_HOME/bin:$PATH"
+export PATH
+
+if have_file "$VOLTA_HOME/bin/npm"; then
+  echo "    node (installed)"
+elif command -v volta >/dev/null 2>&1; then
+  echo "    node (installing latest LTS via volta)"
+  volta install node || warn "volta could not install node"
+else
+  warn "volta is not on PATH; skipped Node and every global npm CLI"
+fi
+
+if have_file "$VOLTA_HOME/bin/npm"; then
+  for pkg in "${GLOBAL_NPM_PACKAGES[@]}"; do
+    # Each entry is a semver range; npm no-ops when the installed version
+    # already satisfies it, so this is both the install and the upgrade path.
+    # --ignore-scripts skips install-time lifecycle scripts, a common
+    # supply-chain vector, exactly as home.nix does.
+    echo "    npm -g $pkg"
+    "$VOLTA_HOME/bin/npm" install -g --ignore-scripts "$pkg" >/dev/null ||
+      warn "npm could not install $pkg"
+  done
+fi
+
+echo "==> Step 7: Go CLIs"
+if command -v go >/dev/null 2>&1; then
+  mkdir -p "$HOME/go/bin"
+  # go.exe is a native Windows program, and MSYS rewrites arguments that look
+  # like paths but never environment variables -- so GOBIN has to be handed
+  # over already in Windows form or Go writes to a "C:\c\Users\..." of its own
+  # invention.
+  GOBIN_WIN="$(cygpath -w "$HOME/go/bin")"
+  for pkg in "${GO_PACKAGES[@]}"; do
+    echo "    go install $pkg"
+    # Pinned @<tag> refs go through Go's module system, which verifies against
+    # sum.golang.org -- the reason home.nix prefers this over each project's
+    # own unpinned curl | sh installer.
+    GOBIN="$GOBIN_WIN" go install "$pkg" ||
+      warn "go install $pkg failed; if it needs cgo, install a C toolchain (winget install MSYS2.MSYS2) and re-run"
+  done
+else
+  warn "go is not on PATH; skipped no-mistakes and treehouse"
+fi
+
+echo "==> Step 8: dotfiles"
+# The Windows half of home.nix's home.file block. Every path that differs from
+# macOS says why on the spot.
+
+# Directories.
+link "$DOTFILES/home/.agents/skills" "$HOME/.agents/skills"
+link "$DOTFILES/home/.config/wezterm" "$HOME/.config/wezterm"
+link "$DOTFILES/home/.pi/agent/agents" "$HOME/.pi/agent/agents"
+# Claude Code reads the same harness sources as pi: one source of truth, two
+# harnesses pointing at it.
+link "$DOTFILES/home/.agents/skills" "$HOME/.claude/skills"
+link "$DOTFILES/home/.pi/agent/agents" "$HOME/.claude/agents"
+# Neovim on Windows resolves stdpath('config') to %LOCALAPPDATA%\nvim, not
+# ~/.config/nvim, so this is the one config directory that moves.
+link "$DOTFILES/home/.config/nvim" "$LOCALAPPDATA_DIR/nvim"
+# The completions are bash `complete -F` scripts. macOS loads them into zsh
+# through bashcompinit from ~/.config/zsh/bin-completion; bash reads them
+# natively from here.
+link "$DOTFILES/home/bin-completion" "$HOME/.config/bash/bin-completion"
+# herdr's config location on Windows is not documented upstream, and its
+# Windows build is a beta. Link both candidates -- the XDG path macOS uses and
+# the %APPDATA% path Windows-native Rust CLIs usually pick -- at the same
+# tracked file, so whichever it reads, it reads this one.
+link "$DOTFILES/home/.config/herdr" "$HOME/.config/herdr"
+link "$DOTFILES/home/.config/herdr" "$APPDATA_DIR/herdr"
+
+# Files.
+link "$DOTFILES/home/.pi/agent/themes/rose-pine-moon.json" "$HOME/.pi/agent/themes/rose-pine-moon.json"
+link "$DOTFILES/home/.pi/agent/models.json" "$HOME/.pi/agent/models.json"
+link "$DOTFILES/home/.pi/agent/settings.json" "$HOME/.pi/agent/settings.json"
+link "$DOTFILES/home/.pi/agent/extensions/terminal-status-title.js" "$HOME/.pi/agent/extensions/terminal-status-title.js"
+link "$DOTFILES/home/.pi/agent/extensions/axi-ambient-context.js" "$HOME/.pi/agent/extensions/axi-ambient-context.js"
+link "$DOTFILES/home/.pi/agent/hook/hooks.yaml" "$HOME/.pi/agent/hook/hooks.yaml"
+link "$DOTFILES/home/.pi/agent/hook/session-start.sh" "$HOME/.pi/agent/hook/session-start.sh"
+link "$DOTFILES/home/AGENTS.md" "$HOME/.claude/CLAUDE.md"
+link "$DOTFILES/home/AGENTS.md" "$HOME/.codex/AGENTS.md"
+link "$DOTFILES/home/gitignore" "$HOME/.gitignore"
+link "$DOTFILES/home/.gitconfig" "$HOME/.gitconfig"
+link "$DOTFILES/home/.gitconfig-windows" "$HOME/.gitconfig-os"
+link "$DOTFILES/home/.ssh/config" "$HOME/.ssh/config"
+link "$DOTFILES/home/.ssh/config-windows" "$HOME/.ssh/config-os"
+link "$DOTFILES/home/.config/1Password/ssh/agent.toml" "$HOME/.config/1Password/ssh/agent.toml"
+link "$DOTFILES/home/.config/mcp/mcp.json" "$HOME/.config/mcp/mcp.json"
+link "$DOTFILES/home/.config/starship.toml" "$HOME/.config/starship.toml"
+# bash is the shell here, so these two stand in for programs.zsh in home.nix.
+link "$DOTFILES/home/.bash_profile" "$HOME/.bash_profile"
+link "$DOTFILES/home/.bashrc" "$HOME/.bashrc"
+# Re-running this script is the rebuild, so devtools-rebuild points at it
+# rather than at rebuild.sh (which is zsh and darwin-rebuild only).
+link "$DOTFILES/setup/windows.sh" "$HOME/.local/bin/devtools-rebuild"
+
+# The custom commands, one link each, exactly as home.nix does it.
+for script in "$SCRIPT_DIR"/home/bin/*; do
+  name="$(basename "$script")"
+  link "$DOTFILES/home/bin/$name" "$HOME/.local/bin/$name"
+done
+
+# Claude Code on Windows needs to be told where bash is before it will run a
+# bash hook -- and every hook in this repo is a bash script.
+CLAUDE_BASH="$(git_bash_path)"
+CURRENT_CLAUDE_BASH="$(powershell.exe -NoProfile -Command \
+  "[Environment]::GetEnvironmentVariable('CLAUDE_CODE_GIT_BASH_PATH','User')" 2>/dev/null | tr -d '\r')"
+if [ "$CURRENT_CLAUDE_BASH" != "$CLAUDE_BASH" ]; then
+  win setx CLAUDE_CODE_GIT_BASH_PATH "$CLAUDE_BASH" >/dev/null
+  echo "    set user CLAUDE_CODE_GIT_BASH_PATH=$CLAUDE_BASH"
+fi
+
+echo "==> Step 9: secrets file"
+# Mirrors home.activation.ensureEnvFile: stub every key without touching a
+# value that is already set, so adding a key later tops the file up.
+ENV_FILE="$HOME/.env"
+if [ ! -e "$ENV_FILE" ]; then
+  install -m 600 /dev/null "$ENV_FILE"
+  {
+    echo "# Secrets sourced by bash on startup. Never commit this file."
+    echo "# Quote values containing spaces or shell metacharacters."
+    echo
+  } >>"$ENV_FILE"
+fi
+for var in "${SECRET_ENV_VARS[@]}"; do
+  if ! grep -q "^$var=" "$ENV_FILE"; then
+    echo "$var=" >>"$ENV_FILE"
+    echo "    stubbed $var in ~/.env -- set its value"
+  fi
+done
+
+echo "==> Step 10: Claude Code settings and MCP servers"
+# Both merges exist for the same reason they do in home.nix: these two files
+# are not exclusively ours. ~/.claude.json also holds auth, history and
+# per-project state, and ~/.claude/settings.json is written by the AXI
+# `setup hooks` commands in Step 11, whose writes would follow a symlink
+# straight into this public repo.
+if ! command -v jq >/dev/null 2>&1; then
+  warn "jq is not on PATH; skipped the Claude Code settings and MCP merges"
+else
+  CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+  SETTINGS_SRC="$SCRIPT_DIR/home/.config/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+  if [ -L "$CLAUDE_SETTINGS" ]; then
+    rm -f "$CLAUDE_SETTINGS"
+  fi
+  CURRENT_SETTINGS="$TMP_ROOT/claude-settings-current.json"
+  if [ -f "$CLAUDE_SETTINGS" ]; then
+    cp "$CLAUDE_SETTINGS" "$CURRENT_SETTINGS"
+  else
+    echo '{}' >"$CURRENT_SETTINGS"
+  fi
+  # `.[0] * .[1]` deep-merges with this repo winning, so settings Claude Code
+  # writes itself survive. hooks.SessionStart is an array, so it is replaced
+  # outright and Step 11 puts the AXI entries back.
+  if jq -s '.[0] * .[1]' "$CURRENT_SETTINGS" "$SETTINGS_SRC" >"$TMP_ROOT/claude-settings.json"; then
+    mv "$TMP_ROOT/claude-settings.json" "$CLAUDE_SETTINGS"
+    echo "    merged ~/.claude/settings.json"
+  else
+    warn "jq merge failed; left ~/.claude/settings.json unchanged"
+  fi
+
+  CLAUDE_JSON="$HOME/.claude.json"
+  MCP_SRC="$HOME/.config/mcp/mcp.json"
+  if [ -f "$CLAUDE_JSON" ] && [ -f "$MCP_SRC" ]; then
+    if jq --slurpfile mcp "$MCP_SRC" \
+      '.mcpServers = ((.mcpServers // {}) + $mcp[0].mcpServers)' \
+      "$CLAUDE_JSON" >"$TMP_ROOT/claude.json"; then
+      mv "$TMP_ROOT/claude.json" "$CLAUDE_JSON"
+      echo "    merged MCP servers into ~/.claude.json"
+    else
+      warn "jq merge failed; left ~/.claude.json unchanged"
+    fi
+  fi
+fi
+
+echo "==> Step 11: AXI ambient-context hooks"
+# Each command is idempotent and repairs a stale binary path after a
+# reinstall, so running it every time is a no-op once everything is in place.
+for tool in "${AXI_AMBIENT_CONTEXT_TOOLS[@]}"; do
+  if have_file "$VOLTA_HOME/bin/$tool"; then
+    echo "    $tool setup hooks"
+    "$VOLTA_HOME/bin/$tool" setup hooks >/dev/null ||
+      warn "\`$tool setup hooks\` failed; agents start without its ambient context"
+  fi
+done
+
+echo "==> Step 12: Windows system defaults"
+# The Windows half of system.defaults in configuration.nix. reg.exe writes the
+# same value on every run, so this is idempotent by construction.
+# windows-parity.md records the macOS defaults that have no equivalent here and
+# the ones deliberately left alone.
+reg_dword() {
+  win reg.exe add "$1" /v "$2" /t REG_DWORD /d "$3" /f >/dev/null
+}
+reg_sz() {
+  win reg.exe add "$1" /v "$2" /t REG_SZ /d "$3" /f >/dev/null
+}
+
+THEMES_KEY="HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"
+EXPLORER_KEY="HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"
+
+reg_dword "$THEMES_KEY" AppsUseLightTheme 0   # NSGlobalDomain.AppleInterfaceStyle = Dark
+reg_dword "$THEMES_KEY" SystemUsesLightTheme 0
+reg_dword "$EXPLORER_KEY" HideFileExt 0       # AppleShowAllExtensions
+reg_dword "$EXPLORER_KEY" HideIcons 1         # finder.CreateDesktop = false
+reg_sz "HKCU\\Control Panel\\Keyboard" KeyboardDelay 0   # InitialKeyRepeat
+reg_sz "HKCU\\Control Panel\\Keyboard" KeyboardSpeed 31  # KeyRepeat
+# trackpad.Clicking = false. Harmless on a machine with no precision touchpad.
+reg_dword "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\PrecisionTouchPad" TapsEnabled 0
+echo "    applied; Explorer settings show up after a sign-out or an Explorer restart"
+
+echo "==> Step 13: 1Password commit signing"
+# The signer's path embeds this machine's username, so it belongs in the
+# untracked ~/.gitconfig.local next to the signing key -- not in the tracked
+# .gitconfig-windows. `git config --file` edits that file surgically, so an
+# existing user.signingkey is left alone.
+OP_SSH_SIGN="$LOCALAPPDATA_DIR/1Password/app/8/op-ssh-sign.exe"
+if [ -f "$OP_SSH_SIGN" ]; then
+  git config --file "$HOME/.gitconfig.local" gpg.ssh.program "$(cygpath -m "$OP_SSH_SIGN")"
+  echo "    pointed gpg.ssh.program at $OP_SSH_SIGN"
+else
+  warn "1Password's op-ssh-sign.exe is not installed yet; run this script again after signing in to 1Password so commit signing gets wired up"
+fi
+
+if ! git config --file "$HOME/.gitconfig.local" --get user.signingkey >/dev/null 2>&1; then
+  cat <<'EOF'
+
+===================================================================
+NEXT STEP: add this machine's git signing key to ~/.gitconfig.local
+
+  [user]
+      signingkey = ssh-ed25519 AAAA...
+===================================================================
+EOF
+fi
+
+echo
+echo "==> Done. Re-run this script (or devtools-rebuild) to apply later changes."
+echo "    Open a new WezTerm window to pick up the new shell configuration."
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo
+  echo "==> ${#WARNINGS[@]} warning(s):"
+  for w in "${WARNINGS[@]}"; do
+    echo "    - $w"
+  done
+fi
+
+cat <<'EOF'
+
+==> Deliberately not installed here; see setup/windows-parity.md for why:
+    herdr        beta on Windows, and its installer is an unpinned
+                 `irm https://herdr.dev/install.ps1 | iex`. Run that by hand
+                 if you want it.
+    twg          upstream supports macOS and Linux only; its installer
+                 refuses to run on Windows.
+    telepresence, weave gitops, tmux, ansible, mas, nix
+EOF

--- a/setup/windows.sh
+++ b/setup/windows.sh
@@ -18,8 +18,19 @@
 
 set -euo pipefail
 
-# The repo root, one level up from this script's own directory.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The repo root, one level up from this script's own directory. Resolved
+# through the symlink first, the same thing rebuild.sh's ${0:A:h} does on
+# macOS: the supported way to re-run this is ~/.local/bin/devtools-rebuild,
+# which is a link to this file, and a plain dirname would land in ~/.local.
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.." && pwd)"
+
+# Cheap guard, because getting this wrong is silent and destructive: Step 3
+# would repoint ~/.dotfiles at the wrong directory and Step 8 would then
+# replace every correct dotfile symlink with a dangling one.
+if [ ! -f "$SCRIPT_DIR/setup/windows.sh" ]; then
+  echo "Error: could not locate the repo root (resolved $SCRIPT_DIR)." >&2
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # What gets installed.
@@ -163,7 +174,6 @@ if ! command -v winget >/dev/null 2>&1; then
 fi
 
 LOCALAPPDATA_DIR="$(cygpath -u "${LOCALAPPDATA:?LOCALAPPDATA is not set}")"
-APPDATA_DIR="$(cygpath -u "${APPDATA:?APPDATA is not set}")"
 
 TMP_ROOT="$(mktemp -d)"
 cleanup() { rm -rf "$TMP_ROOT"; }
@@ -333,7 +343,6 @@ else
   if curl -fsSL --retry 2 -o "$FONT_ZIP" \
     "https://github.com/ryanoasis/nerd-fonts/releases/download/v${HACK_NERD_FONT_VERSION}/Hack.zip"; then
     mkdir -p "$FONT_EXTRACT" "$FONT_DIR"
-    mkdir -p "$FONT_EXTRACT" "$FONT_DIR"
     # Git Bash's tar cannot read zip archives; PowerShell's Expand-Archive is
     # always present and can.
     powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
@@ -462,11 +471,13 @@ link "$DOTFILES/home/.config/nvim" "$LOCALAPPDATA_DIR/nvim"
 # natively from here.
 link "$DOTFILES/home/bin-completion" "$HOME/.config/bash/bin-completion"
 # herdr's config location on Windows is not documented upstream, and its
-# Windows build is a beta. Link both candidates -- the XDG path macOS uses and
-# the %APPDATA% path Windows-native Rust CLIs usually pick -- at the same
-# tracked file, so whichever it reads, it reads this one.
+# Windows build is a beta. Only the XDG path macOS uses is linked. The
+# %APPDATA%\herdr link is deliberately not created: %APPDATA%\<app> is where a
+# Windows app writes runtime state, and a third-party write through an
+# out-of-store symlink lands in this tracked public checkout -- the pattern
+# AGENTS.md warns about. If herdr on Windows turns out to read %APPDATA%
+# instead, copy the config there; never link it.
 link "$DOTFILES/home/.config/herdr" "$HOME/.config/herdr"
-link "$DOTFILES/home/.config/herdr" "$APPDATA_DIR/herdr"
 
 # Files.
 link "$DOTFILES/home/.pi/agent/themes/rose-pine-moon.json" "$HOME/.pi/agent/themes/rose-pine-moon.json"
@@ -609,7 +620,40 @@ reg_sz "HKCU\\Control Panel\\Keyboard" KeyboardSpeed 31  # KeyRepeat
 reg_dword "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\PrecisionTouchPad" TapsEnabled 0
 echo "    applied; Explorer settings show up after a sign-out or an Explorer restart"
 
-echo "==> Step 13: 1Password commit signing"
+echo "==> Step 13: Windows OpenSSH client"
+# home/.gitconfig-windows pins core.sshCommand to this exact binary, because it
+# is the only ssh that can reach 1Password's named-pipe agent. It ships as an
+# optional Windows feature, so a machine without it fails every git fetch and
+# push with a bare "cannot run" error. Resolve it from SystemRoot rather than
+# hardcoding C:, and install the inbox capability when it is missing -- not the
+# winget OpenSSH package, which installs somewhere else entirely and would not
+# satisfy the pinned path.
+SYSTEM_ROOT_DIR="$(cygpath -u "${SystemRoot:-${SYSTEMROOT:-C:\\Windows}}")"
+OPENSSH_CLIENT="$SYSTEM_ROOT_DIR/System32/OpenSSH/ssh.exe"
+if [ -f "$OPENSSH_CLIENT" ]; then
+  echo "    already installed ($OPENSSH_CLIENT)"
+else
+  echo "    not installed; enabling the OpenSSH Client capability (expect one UAC prompt)"
+  OPENSSH_PS1="$TMP_ROOT/install-openssh-client.ps1"
+  cat >"$OPENSSH_PS1" <<'PS1'
+$name = 'OpenSSH.Client~~~~0.0.1.0'
+$cap = Get-WindowsCapability -Online -Name $name -ErrorAction SilentlyContinue
+if ($cap -and $cap.State -ne 'Installed') {
+  Add-WindowsCapability -Online -Name $name | Out-Null
+}
+PS1
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
+    "Start-Process -Verb RunAs -Wait -FilePath powershell.exe -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$(cygpath -w "$OPENSSH_PS1")'" \
+    >/dev/null 2>&1 || true
+
+  if [ -f "$OPENSSH_CLIENT" ]; then
+    echo "    installed"
+  else
+    warn "the Windows OpenSSH client is still missing from $OPENSSH_CLIENT; git over SSH will fail because .gitconfig-windows routes core.sshCommand through that exact path. From an elevated PowerShell run: Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0"
+  fi
+fi
+
+echo "==> Step 14: 1Password commit signing"
 # The signer's path embeds this machine's username, so it belongs in the
 # untracked ~/.gitconfig.local next to the signing key -- not in the tracked
 # .gitconfig-windows. `git config --file` edits that file surgically, so an


### PR DESCRIPTION
## Intent

The developer is migrating their personal dev environment from Ansible playbooks to a Nix/nix-darwin/home-manager flake, currently focused on the macOS (Apple Silicon) portion while keeping the legacy Ansible/Windows path as unmigrated reference. Across the session they wanted Nix to install and configure a specific set of tools (1Password and its CLI/SSH agent, Docker, kubectl, Flux, GitOps, Terraform, Ansible, Raycast, Volta for Node, Telepresence, Lens, various AXI npm tools, Go-based CLIs like no-mistakes and treehouse, plannotator, and a Mac App Store app), migrate their custom bin scripts and zsh completions into the repo as symlinks, and convert those scripts and rebuild.sh from bash to zsh. They also asked for OS-specific gitconfig via git includes, split SSH config to keep private host entries out of the public repo, an optional ~/.env secret-stubbing mechanism, pi agent hooks/subagents wiring, disabling Spotlight indexing, making setup.sh auto-dispatch by OS/platform with a clear unsupported message, and a README centered on capabilities, install steps, and supported platforms. Explicit constraints included preferring toolchain-managed/pinned installs over unpinned curl-pipe-sh scripts, never using em dashes, not auto-adding co-author lines, and changing Homebrew cleanup to not remove unreferenced packages (with AGENTS.md updated to record that as the deliberate choice).

## What Changed

- Added `setup/windows.sh`, a full native-Windows setup path (Git Bash, not WSL) covering winget package installs, Nerd Font and kubeseal downloads, dotfile symlinking, registry/system defaults, 1Password commit signing, and the Windows OpenSSH Client capability, plus `setup.sh` dispatch to it and a repo-root guard so an out-of-repo copy or the `~/.local/bin/devtools-rebuild` symlink resolves correctly.
- Added the bash side of the shared shell: `home/.bash_profile`, `home/.bashrc` (PATH, session vars, `~/.env` sourcing with unset-secret warnings, aliases, completions, starship), Windows-aware `wezterm.lua` `default_prog` and `starship.toml` entries, and reworked `home/.gitconfig-windows` / `home/.ssh/config-windows` for native Windows.
- Converted the `home/bin/` scripts to portable bash so they run on both platforms, including CRLF stripping in `aup` and `kaup` when parsing native `netstat`/`tasklist` output.
- Documented the two-platform contract: new `setup/windows-parity.md` mapping every macOS package, config, and system default to its Windows decision, plus `readme.md` and `AGENTS.md` updates and `home.nix` adjustments.

Note on open items from the pipeline: two low-severity infos remain unaddressed - a `home/.bashrc` secret-name guard that lets an empty or digit-leading key reach `${!_var}`, and the `readme.md` install summary not listing the new OpenSSH Client step. The Windows-only halves of `setup/windows.sh` (winget installs, downloads, symlink step, registry defaults, OpenSSH capability) could not be executed from the macOS machine this ran on and remain unverified; shellcheck and `bash -n` passed, and the shared shell, bin scripts, wezterm, and setup entrypoints were exercised end to end.

## Risk Assessment

✅ Low: Every prior finding, including the destructive repo-root resolution bug, is fixed with a matching fail-loud guard, the docs and parity contract were updated in step, shellcheck is clean, and the only remaining items are two cosmetic robustness/documentation nits confined to the additive Windows path.

## Testing

I exercised the branch the way a Windows user would meet it, from macOS: a real login shell over the new .bash_profile/.bashrc in a throwaway HOME (PATH, session vars, ~/.env secrets warning, aliases, completions, starship prompt), the aup/kaup Windows branch against stub netstat/tasklist/taskkill emitting genuine CRLF, the devtools-rebuild symlink path into setup/windows.sh, ./setup.sh OS dispatch, the bash-converted home/bin commands against a scratch git repo, and the wezterm.lua Windows default-shell branch under lua. Each of the three fixes in the review commit was run at both HEAD~1 and HEAD, and the before/after transcripts show the old behavior failing exactly as described (name printed as "?", a "killed" message while taskkill errored, and a repo root resolving to ~/.local) and the new behavior correct. nix eval confirms the macOS configuration still evaluates and the npm/Go/secret lists match between home.nix and setup/windows.sh. Everything passed; the only gap is that the winget installs, registry defaults, symlink step and the new OpenSSH capability step cannot execute outside Git Bash, so they remain untested here.

- Evidence: Windows Git Bash startup, rendered with the shell&#39;s real colors (local file: <code>/var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/no-mistakes-evidence/01KZRJZZ0FS379JNTRKG9G2VKN/windows-bash-startup.png</code>)
<details>
<summary>Evidence: Same startup transcript as rendered HTML</summary>

```text
<!doctype html><meta charset="utf-8"><title>Windows Git Bash startup</title>
<style>body{background:#1b1b26;margin:0;padding:28px;font-family:"Hack Nerd Font","JetBrains Mono",Menlo,monospace}
h1{color:#f8f8f2;font-size:15px;font-weight:600;margin:0 0 4px}
p{color:#9aa0b5;font-size:12px;margin:0 0 18px;max-width:70ch;line-height:1.5}
pre{color:#f8f8f2;font-size:12.5px;line-height:1.55;white-space:pre-wrap;word-break:break-word;margin:0;
 background:#12121b;border:1px solid #2a2a3c;border-radius:8px;padding:18px}</style>
<h1>What a Windows shell looks like after setup/windows.sh</h1>
<p>Real transcript of <code>bash --login -i</code> against this branch's <code>home/.bash_profile</code> and
<code>home/.bashrc</code>, symlinked into a throwaway HOME the way step 8 links them. Colours are the actual
escape sequences the shell emitted, including the starship prompt from the shared <code>starship.toml</code>
and the unset-secret warning.</p>
<pre>### login shell start (bash --login -i), HOME=/var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/tmp.rRZ1uYsPBt

bash: cannot set terminal process group (92717): Inappropriate ioctl for device
bash: no job control in this shell
⚠  Unset secrets in ~/.env: CONTEXT7_API_KEY
   Set them there before using tooling that needs them.
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;--- PATH front (home.nix&#x27;s PATH loop, ported to bash) ---&quot;
--- PATH front (home.nix&#x27;s PATH loop, ported to bash) ---
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;$PATH&quot; | tr &#x27;:&#x27; &#x27;\n&#x27; | head -3
~/.local/bin
~/go/bin
/opt/homebrew/bin
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo

<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;--- session variables ---&quot;
--- session variables ---
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;EDITOR=$EDITOR  REPO_HOME=$REPO_HOME  VOLTA_HOME=$VOLTA_HOME&quot;
EDITOR=nvim  REPO_HOME=~/developer/repos  VOLTA_HOME=/Users/andrew/.volta
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> 
&lt;purpose: 1Password serves a named pipe on Windows)&quot;
SSH_AUTH_SOCK=[unset]  (.bashrc sets none on purpose: 1Password serves a named pipe on Windows)
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo

<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;--- secrets sourced from ~/.env under set -a ---&quot;
--- secrets sourced from ~/.env under set -a ---
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;ALREADY_SET_KEY=$ALREADY_SET_KEY&quot;
ALREADY_SET_KEY=sk-live-value
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;CONTEXT7_API_KEY=[${CONTEXT7_API_KEY:-empty}]&quot;
CONTEXT7_API_KEY=[empty]
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo

<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;--- aliases (home.nix&#x27;s shellAliases) ---&quot;
--- aliases (home.nix&#x27;s shellAliases) ---
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> alias m; alias cc; alias ..
alias m=&#x27;git switch main&#x27;
alias cc=&#x27;claude --dangerously-skip-permissions&#x27;
alias ..=&#x27;cd ..&#x27;
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo

<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> echo &quot;--- completions loaded from ~/.config/bash/bin-completion ---&quot;
--- completions loaded from ~/.config/bash/bin-completion ---
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> complete -p aup db gco 2&gt;/dev/null || echo &quot;(none registered)&quot;
complete -F _aup_complete aup
complete -F _db_complete db
complete -F _gco_complete gco
<span style="font-weight:600;color:#8be9fd">01KZRJZZ0FS379JNTRKG9G2VKN</span> on <span style="font-weight:600;color:#bd93f9"> HEAD</span> 
<span style="color:#bd93f9">❯</span> logout
</pre>
```
</details>
<details>
<summary>Evidence: aup / kaup CRLF fix, before and after</summary>

<code>### home/bin/aup 3000 -- Windows branch (no lsof; netstat/tasklist emit CRLF)&#10;&#10;$ aup 3000 # (before: HEAD~1)&#10;? 7421&lt;CR&gt; LISTENING 0.0.0.0:3000&#10;&#10;$ aup 3000 # (after: HEAD)&#10;node.exe 7421 LISTENING 0.0.0.0:3000&#10;&#10;### home/bin/kaup 3000 -- Windows branch (taskkill rejects a pid with a stray CR)&#10;&#10;$ kaup 3000 # (before: HEAD~1)&#10;ERROR: The process &#34;7421&lt;CR&gt;&#34; not found.&lt;CR&gt;&#10;Killed process 7421&lt;CR&gt; listening on port 3000&#10;&#10;$ kaup 3000 # (after: HEAD)&#10;Killed process 7421 listening on port 3000</code>

```text
### home/bin/aup 3000 -- Windows branch (no lsof; netstat/tasklist emit CRLF)

$ aup 3000        # (before: HEAD~1)
?	7421<CR>	LISTENING	0.0.0.0:3000
  [exit 0]

$ aup 3000        # (after: HEAD)
node.exe	7421	LISTENING	0.0.0.0:3000
  [exit 0]

### home/bin/kaup 3000 -- Windows branch (taskkill rejects a pid with a stray CR)

$ kaup 3000        # (before: HEAD~1)
ERROR: The process "7421<CR>" not found.<CR>
Killed process 7421<CR> listening on port 3000
  [exit 0]

$ kaup 3000        # (after: HEAD)
Killed process 7421 listening on port 3000
  [exit 0]

### macOS branch unchanged: aup on a port this shell is really listening on

$ aup 58205
lsof: WARNING: can't stat() smbfs file system /Volumes/.timemachine/nas-01._smb._tcp.local./2331A137-DEC5-4A6E-A00C-942D434CEB2A/backup
      Output information may be incomplete.
      assuming "dev=36000195" from mount table
Python  95787 andrew    3u  IPv4 0x57dc5614b195759a      0t0  TCP 127.0.0.1:58205 (LISTEN)
```
</details>
<details>
<summary>Evidence: setup.sh dispatch and windows.sh repo-root resolution</summary>

<code>$ ./setup.sh # on an unsupported platform (macOS reporting x86_64)&#10;==&gt; Detected: macos / x86_64&#10;Error: Unsupported platform: macos / x86_64&#10;Currently supported: macOS on Apple Silicon (arm64), Windows on x86_64.&#10;&#10;$ ~/.local/bin/devtools-rebuild # (before: HEAD~1)&#10;resolved repo root: .../home/.local&#10;contains setup/windows.sh: NO -- ~/.dotfiles and every dotfile symlink would point here&#10;&#10;$ ~/.local/bin/devtools-rebuild # (after: HEAD)&#10;resolved repo root: .../HEAD&#10;contains setup/windows.sh: yes&#10;&#10;$ /tmp/loose-copy/windows.sh # after: script copied out of the repo&#10;Error: could not locate the repo root (resolved ...).</code>

```text
### 1. ./setup.sh dispatch

$ ./setup.sh            # on an unsupported platform (macOS reporting x86_64)
==> Detected: macos / x86_64
Error: Unsupported platform: macos / x86_64
Currently supported: macOS on Apple Silicon (arm64), Windows on x86_64.
  [exit 1]

$ OSTYPE=msys ./setup.sh   # Windows: dispatches to setup/windows.sh, which
                           # then refuses because this is not Git Bash
==> Detected: windows / x86_64
Error: winget is not on PATH.
It ships with Windows 11 as App Installer. Install or update it from
the Microsoft Store ('App Installer'), then re-run this script.
  [exit 1]

### 2. repo-root resolution in setup/windows.sh

$ ~/.local/bin/devtools-rebuild        # (before: HEAD~1)
  resolved repo root: /var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/tmp.uxfZvq2Jn0/home/.local
  contains setup/windows.sh: NO -- ~/.dotfiles and every dotfile symlink would point here
  Error: setup/windows.sh has to run from Git for Windows' bash.
  Detected OSTYPE='darwin25.4.0'.
  [exit 1]

$ ~/.local/bin/devtools-rebuild        # (after: HEAD)
  resolved repo root: /private/var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/tmp.uxfZvq2Jn0/HEAD
  contains setup/windows.sh: yes
  Error: setup/windows.sh has to run from Git for Windows' bash.
  Detected OSTYPE='darwin25.4.0'.
  [exit 1]

$ /tmp/loose-copy/windows.sh          # after: script copied out of the repo
  Error: could not locate the repo root (resolved /private/var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/tmp.uxfZvq2Jn0).
  [exit 1]
```
</details>
<details>
<summary>Evidence: wezterm default_prog on Windows and macOS, plus the shared starship prompt</summary>

<code>$ wezterm on Windows, machine-wide Git install&#10;default_prog = { .../ProgramFiles\Git\bin\bash.exe, -l }&#10;$ wezterm on Windows, per-user Git install only (%ProgramFiles% unset)&#10;default_prog = { .../LocalAppData\Programs\Git\bin\bash.exe, -l }&#10;$ wezterm on Windows, no Git installed anywhere&#10;default_prog = (unset -- WezTerm&#39;s own default shell)&#10;$ wezterm on macOS (the branch must not fire)&#10;default_prog = (unset -- WezTerm&#39;s own default shell)</code>

```text
### wezterm.lua default_prog on Windows

$ wezterm on Windows, machine-wide Git install
  default_prog = { /var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/tmp.l3INRvvFZj/ProgramFiles\Git\bin\bash.exe, -l }
$ wezterm on Windows, per-user Git install only (%ProgramFiles% unset)
  default_prog = { /var/folders/mc/mzp6sm4d449b277kc1h4y3kw0000gn/T/tmp.l3INRvvFZj/LocalAppData\Programs\Git\bin\bash.exe, -l }
$ wezterm on Windows, no Git installed anywhere
  default_prog = (unset -- WezTerm's own default shell)
$ wezterm on macOS (the branch must not fire)
  default_prog = (unset -- WezTerm's own default shell)

### shared home/.config/starship.toml, rendered by starship

  %{[1;36m%}01KZRJZZ0FS379JNTRKG9G2VKN%{[0m%} on %{[1;35m%} HEAD%{[0m%} 
%{[35m%}❯%{[0m%} 
```
</details>
<details>
<summary>Evidence: home/bin commands running under bash</summary>

```text
### home/bin commands under bash, PATH=~/.local/bin (shebang: #!/usr/bin/env bash)

$ st
  On branch main
  nothing to commit, working tree clean

$ glg
  * 36aec82 - (HEAD -> main) third commit (0 seconds ago) <Tester>
  * 3774e1b - second commit (0 seconds ago) <Tester>
  * 4cfa896 - first commit (0 seconds ago) <Tester>
$ projs
  alpha-api
  alpha-web
  beta-tools

$ projs alpha
  alpha-api
  alpha-web

$ gnxt main   # from the first commit, step forward one
  Previous HEAD position was 4cfa896 first commit
  HEAD is now at 3774e1b second commit
  HEAD is now: second commit

$ echo scratch > b.txt; stash; st
  Saved working directory and index state WIP on main: 36aec82 third commit
  (stash list: 1 entry)

$ rh          # reset --hard + clean -fd
  HEAD is now at 36aec82 third commit
  Removing untracked.txt
  worktree after: 0 changed paths

$ gwta ../wt-demo demo
  Preparing worktree (checking out 'demo')
  HEAD is now at 36aec82 third commit
  worktrees: 2
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (8m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `readme.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `setup/windows.sh:22` - SCRIPT_DIR is computed as dirname &#34;${BASH_SOURCE[0]}&#34;/.. which does not resolve symlinks. Step 8 links this file to ~/.local/bin/devtools-rebuild, and readme.md documents `devtools-rebuild` as the way to apply later changes on Windows. Invoked that way, BASH_SOURCE[0] is ~/.local/bin/devtools-rebuild, so SCRIPT_DIR becomes $HOME/.local. Step 3 then does `rm -f ~/.dotfiles` and relinks it to $HOME/.local, and Step 8 recreates every dotfile link pointing at $HOME/.local/home/... (dangling), removing the correct links on the way; the `for script in &#34;$SCRIPT_DIR&#34;/home/bin/*` loop matches nothing and creates a symlink literally named `*`. rebuild.sh already handles this with `SCRIPT_DIR=&#34;${0:A:h}&#34;` and a comment explaining the devtools-rebuild case. Fix: resolve the source path first, e.g. SCRIPT_DIR=&#34;$(cd &#34;$(dirname &#34;$(readlink -f &#34;${BASH_SOURCE[0]}&#34;)&#34;)/..&#34; &amp;&amp; pwd)&#34;.
- ⚠️ `home/bin/kaup:14` - netstat is a native Windows program, so its output lines end in CRLF and the last awk field ($5, the PID) carries a trailing \r. `taskkill /F /PID &#34;1234\r&#34;` fails, its error goes to stderr (only stdout is redirected) and the script has no `set -e`, so kaup then prints &#34;Killed process 1234 listening on port N&#34; while the process is still alive. setup/windows.sh already applies `| tr -d &#39;\r&#39;` to native-program output twice, so the pattern is known; add the same here (e.g. pipe the netstat output through `tr -d &#39;\r&#39;`).
- ⚠️ `home/bin/aup:14` - Same CRLF problem on the read side: the PID field parsed out of netstat retains a trailing \r, so `tasklist /FI &#34;PID eq 1234\r&#34;` never matches and every row prints the `?` placeholder instead of a process name, with the stray CR also mangling the printf&#39;d line in the terminal. Strip \r from the netstat output before the awk parse.
- ℹ️ `setup/windows.sh:336` - `mkdir -p &#34;$FONT_EXTRACT&#34; &#34;$FONT_DIR&#34;` is repeated verbatim on lines 335 and 336. Harmless, but one of the two should go.
- ℹ️ `home/.bashrc:128` - The required-secret list now exists in three places (secretEnvVars in home.nix, SECRET_ENV_VARS in setup/windows.sh, _secret_vars here), and readme.md&#39;s Customizing table instructs bumping all three. The shell copy is avoidable: the warning could iterate the keys already stubbed into ~/.env and report the ones with empty values, which keeps the list at two declarations. This changes what the warning covers slightly (any empty key in ~/.env, not a hardcoded set), so it is a call for the author.
- ℹ️ `home/.gitconfig-windows:9` - core.sshCommand is pinned to the absolute C:/Windows/System32/OpenSSH/ssh.exe. The reasoning for not using a bare `ssh.exe` is sound, but the OpenSSH Client is an optional Windows feature and setup/windows.sh never checks for it, so on a machine without it every git fetch/push fails with a bare &#39;cannot run&#39; error and nothing in the setup output hints at the cause. A preflight `[ -f /c/Windows/System32/OpenSSH/ssh.exe ] || warn ...` in windows.sh would surface it at setup time.
- ℹ️ `setup/windows.sh:469` - home/.config/herdr is linked as a directory into both ~/.config/herdr and %APPDATA%\herdr. %APPDATA%\&lt;app&gt; is conventionally where a Windows app writes runtime state, not just config, and the tracked directory already contains a herdr-written .plugins.lock - so anything herdr writes there (state, tokens) lands in this public checkout. That is the pattern AGENTS.md warns about for third-party writes through out-of-store symlinks. The parity doc records the double link as deliberate, and herdr is not installed on Windows today, so this is a heads-up rather than a defect.
- ℹ️ `home.nix:288` - The comment above the .ssh/config-os entry still says the OS-specific bits are &#39;(the 1Password IdentityAgent path on macOS; nothing needed on WSL)&#39;. This branch retargets the Windows path to native Windows and rewrites home/.ssh/config-windows accordingly, so the WSL reference is now wrong.

🔧 Fix: Fix Windows setup script root resolution, CRLF parsing, and OpenSSH step
2 infos still open:
- ℹ️ `home/.bashrc:144` - The derived-secret loop validates the key with `case &#34;$_var&#34; in *[!A-Za-z0-9_]*) continue`, which accepts two names that are not valid bash identifiers: the empty string (a line beginning with `=`) and a digit-leading name (e.g. `1PASSWORD_TOKEN=`, plausible in this environment). `${!_var:-}` then aborts that command with `bash: : invalid variable name` / `bash: 1PASSWORD_TOKEN: invalid variable name` on stderr at every shell start, and in the empty case a blank entry is appended to the reported list. Sourcing continues, so the impact is a spurious error line rather than a broken rc. Fix: extend the guard to `case &#34;$_var&#34; in &#39;&#39; | [0-9]* | *[!A-Za-z0-9_]*) continue ;; esac`.
- ℹ️ `readme.md:51` - The Windows install summary enumerates what setup/windows.sh does, and item 7 still ends at &#34;applies the Windows system defaults, and wires up 1Password commit signing&#34; - it does not mention the new step that installs the Windows OpenSSH Client capability, which is the one that can raise an extra UAC prompt on a fresh machine. setup/windows-parity.md was updated; this list was not.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `setup/windows.sh:174` - The Windows-only half of setup/windows.sh cannot be executed from this macOS machine: the script exits at its Git Bash preflight, so the winget package installs (step 1-4), the Nerd Font and kubeseal downloads, the dotfile symlink step 8, the registry/system defaults step 12, and the new OpenSSH Client capability step 13 are all unverified. Root resolution, the new repo-root guard, and every shared shell/bin/wezterm file were verified; the install and system-mutation steps need a real Windows machine before this can be called proven.
- <code>`bash run-shell-startup.sh &lt;repo&gt;` - login shell against home/.bash_profile + home/.bashrc in a throwaway HOME: PATH loop, session vars, ~/.env sourcing, unset-secret warning, aliases, bin-completions, starship prompt</code>
- <code>`bash run-crlf-port-tools.sh &lt;repo&gt; 249fb25` - home/bin/aup and home/bin/kaup Windows branch (no lsof; stub netstat/tasklist/taskkill emitting CRLF), run at HEAD~1 and HEAD; plus aup on a real listening port to confirm the macOS branch is unchanged</code>
- <code>`bash run-setup-entrypoints.sh &lt;repo&gt; 249fb25` - ./setup.sh unsupported-platform and windows dispatch; setup/windows.sh repo-root resolution via a ~/.local/bin/devtools-rebuild symlink at HEAD~1 vs HEAD; new root guard against a copy outside the repo</code>
- <code>`bash run-bin-scripts.sh &lt;repo&gt;` - st, glg, projs, projs alpha, gnxt, stash, rh, gwta under bash from ~/.local/bin against a scratch git repo</code>
- <code>`bash run-wezterm-and-prompt.sh &lt;repo&gt;` - wezterm.lua default_prog under lua with a stubbed wezterm module for machine-wide Git, per-user-only Git, no Git, and macOS; starship prompt rendered from home/.config/starship.toml</code>
- <code>`nix eval .#darwinConfigurations.mac.system.outPath` - macOS configuration still evaluates after the home.nix changes</code>
- <code>`grep` comparison of globalNpmPackages / goPackages / secretEnvVars in home.nix against GLOBAL_NPM_PACKAGES / GO_PACKAGES / SECRET_ENV_VARS in setup/windows.sh</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `setup/windows.sh:48` - shfmt -d reports diffs in setup/windows.sh (and pre-existing ones in setup/macOS.sh, home/.bashrc, rebuild.sh). The repo has no shfmt config or CI enforcing it, and applying it would collapse the deliberately aligned trailing-comment columns in WINGET_PACKAGES and the reg_* block, hurting readability. Left unformatted on purpose; adopting shfmt repo-wide would be a separate decision.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
