### PR TITLE
chore(home.nix): bump no-mistakes pin to v1.48.0

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -31,13 +31,16 @@ let
   # verification; `go install @<tag>` instead goes through Go's module
   # system, which verifies against sum.golang.org.
   goPackages = [
-    "github.com/kunchenguid/no-mistakes/cmd/no-mistakes@v1.41.2" # https://github.com/kunchenguid/no-mistakes/releases
-    # Pinned to v1.8.0: every v2.x tag (through at least v2.1.1) is broken
-    # upstream -- they tagged v2 releases without bumping go.mod's module
-    # path to ".../treehouse/v2" as Go's semantic import versioning
-    # requires, so `go install` rejects every v2.x ref with "invalid
-    # version: module contains a go.mod file, so module path must match
-    # major version". Bump this once upstream fixes go.mod on a new tag.
+    "github.com/kunchenguid/no-mistakes/cmd/no-mistakes@v1.48.0" # https://github.com/kunchenguid/no-mistakes/releases
+    # Pinned to v1.8.0: every v2.x tag (through at least v2.1.1, the latest
+    # tag as of 2026-08-12) is broken upstream -- they tagged v2 releases
+    # without bumping go.mod's module path to ".../treehouse/v2" as Go's
+    # semantic import versioning requires, so `go install` rejects every
+    # v2.x ref with "invalid version: module contains a go.mod file, so
+    # module path must match major version". Checked go.mod on both v2.0.0
+    # and v2.1.1 via the GitHub contents API; both still declare module
+    # "github.com/kunchenguid/treehouse" with no /v2 suffix, so this is
+    # still broken. Bump this once upstream fixes go.mod on a new tag.
     "github.com/kunchenguid/treehouse@v1.8.0"                     # https://github.com/kunchenguid/treehouse/releases
   ];
   # Secrets referenced by tooling that reads them from the environment --


### PR DESCRIPTION
## Summary
- Bump `no-mistakes` from `v1.41.2` to `v1.48.0`, the latest non-prerelease tag on [kunchenguid/no-mistakes](https://github.com/kunchenguid/no-mistakes/releases) (v1.49.0 exists but is marked prerelease).
- Leave `treehouse` pinned at `v1.8.0`. Checked `go.mod` on both the `v2.0.0` and `v2.1.1` tags of [kunchenguid/treehouse](https://github.com/kunchenguid/treehouse) via the GitHub contents API -- both still declare `module github.com/kunchenguid/treehouse` without the `/v2` suffix Go's semantic import versioning requires for a v2 module, so `go install github.com/kunchenguid/treehouse@v2.x` is still expected to fail with "invalid version: module contains a go.mod file, so module path must match major version". `go` wasn't available in this worktree to empirically re-run the install, but the go.mod evidence is conclusive on its own. Updated the comment to record what was checked and that `v2.1.1` (still the latest tag) remains the tested-broken ceiling.
- Leave `twgVersion` pinned at `1.1.1`. Confirmed against Atlassian's published [twg CLI changelog](https://developer.atlassian.com/cloud/twg-cli/changelog/) that `1.1.1` is still the latest Stable/GA release; newer `1.2.0`-`1.2.4` entries exist but are all labeled Beta.

## Test plan
- [x] `nix flake check` passes (build skipped, evaluation succeeds)
- [x] No unrelated changes to `home.nix`