### PR TITLE
fix(mcp): add missing type to context7 MCP server entry

### DIFF
--- a/home/.config/mcp/mcp.json
+++ b/home/.config/mcp/mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "context7": {
+      "type": "http",
       "url": "https://mcp.context7.com/mcp",
       "headers": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"


### PR DESCRIPTION
## Summary
- Add `"type": "http"` to the `context7` MCP server entry in `home/.config/mcp/mcp.json`

## Test plan
- [x] Validated JSON with `python3 -m json.tool`
- [x] Confirmed no other entries changed via `git diff`